### PR TITLE
specify rust 1.29+ dependency in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ When suggesting a command, McFly takes into consideration:
 
 ### Compile it yourself
 
-1. [Install Rust](https://www.rust-lang.org/en-US/install.html)
+1. [Install Rust 1.29 or later](https://www.rust-lang.org/en-US/install.html)
 1. Compile with optimizations
     ```bash
     cargo build --release


### PR DESCRIPTION
I had to upgrade from rust 1.26 to 1.29 to get your dependency `rusqlite v0.14.0` to build