### PR TITLE
added a dev script that builds and runs a vanilla shell w/ mcfly preloaded

### DIFF
--- a/dev.bash
+++ b/dev.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Build mcfly and run a dev environment bash for local mcfly testing
+
+set -e
+this_dir=$(cd `dirname "$0"`; pwd)
+
+cargo build
+PATH="$PATH:$this_dir/target/debug" \
+MCFLY_DEBUG=1 \
+    exec /bin/bash --init-file "$this_dir/mcfly-bash.sh" -i

--- a/mcfly-bash.sh
+++ b/mcfly-bash.sh
@@ -6,6 +6,14 @@ if [[ "$__mcfly_loaded" == "loaded" ]]; then
 fi
 __mcfly_loaded="loaded"
 
+mcfly_cmd() {
+  if [[ "$MCFLY_DEBUG" = "1" ]]; then
+    echo "RUST_BACKTRACE=1 mcfly"
+  else
+    echo "mcfly"
+  fi
+}
+
 # Ignore duplicate commands or those with a leading space
 # ("ignoreboth" is the same as "ignorespace:ignoredups")
 export HISTCONTROL="ignoreboth" 
@@ -19,11 +27,10 @@ shopt -s histappend
 #   3. run mcfly, telling it the exit status (it will find the last command in the history)
 #   4. clear the in-memory history and reload it from disk
 #   5. run whatever was already in the $PROMPT_COMMAND
-export PROMPT_COMMAND="__last_exit=\$?;history -a;mcfly add --exit \$__last_exit;history -c;history -r;${PROMPT_COMMAND}"
+export PROMPT_COMMAND="__last_exit=\$?;history -a;$(mcfly_cmd) add --exit \$__last_exit;history -c;history -r;${PROMPT_COMMAND}"
 
 # If this is an interactive shell, take ownership of ctrl-r.
 if [[ $- =~ .*i.* ]]; then
-  # bind "'\C-r': '\C-a RUST_BACKTRACE=1 mcfly search \'\C-e\'\C-j'"
-  bind "'\C-r': '\C-a\e# mcfly search\C-j'"
+  bind "'\C-r': '\C-a\e# $(mcfly_cmd) search\C-j'"
 fi
 


### PR DESCRIPTION
This makes it simple to build changes and test them locally without injecting a dev / debug build of mcfly into your primary shell environment.

To use it, simply execute the new `dev.bash` script, and you will be dropped into a vanilla bash shell with mcfly bindings pre-wired through the `mcfly-bash.sh` init script
