### PR TITLE
Use clobbering redirects.

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -11,9 +11,9 @@ export HISTFILE="${HISTFILE:-$HOME/.bash_history}"
 
 if [[ -f "$HISTFILE" ]];
 then
-  tail -n100 ${HISTFILE} > ${MCFLY_HISTORY}
+  tail -n100 ${HISTFILE} >| ${MCFLY_HISTORY}
 else
-  printf "Welcome to McFly\n" > ${MCFLY_HISTORY}
+  printf "Welcome to McFly\n" >| ${MCFLY_HISTORY}
 fi
 
 # Ignore commands with a leading space


### PR DESCRIPTION
Bash's `set -o noclobber` prevents `>` redirects from overwriting files. Use `>|` overwriting redirects so that mcfly works even when the user has set this option.