### PR TITLE
Fix tr behavior on macOS.

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -5,7 +5,7 @@ if [[ "$__MCFLY_LOADED" == "loaded" ]]; then
   return 0
 fi
 __MCFLY_LOADED="loaded"
-export MCFLY_SESSION_ID=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 24 | head -n 1)
+export MCFLY_SESSION_ID=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 24 | head -n 1)
 export MCFLY_HISTORY=$(mktemp -t mcfly.XXXX)
 export HISTFILE="${HISTFILE:-$HOME/.bash_history}"
 


### PR DESCRIPTION
With `LC_CTYPE=C` it fails with `tr: Illegal byte sequence`. `LC_ALL=C` seems to work fine.