### PR TITLE
Light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ To avoid McFly's UI messing up your scrollback history in iTerm2, make sure this
 
 <img src="/docs/iterm2.jpeg" alt="iterm2 UI instructions">
 
+## Light Mode
+
+To swap the color scheme for use in a light terminal, set the environment variable `MCFLY_LIGHT`.
+
+For example, add the following to your `~/.bash_profile`:
+
+```bash
+export MCFLY_LIGHT=TRUE
+```
+
 ## Possible Future Features
 
 * Add a screencast to README.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -173,7 +173,11 @@ impl<'a> Interface<'a> {
         }
 
         for (index, command) in self.matches.iter().enumerate() {
-            let mut fg = color::Fg(color::LightWhite).to_string();
+            let mut fg = if self.settings.lightmode {
+                color::Fg(color::Black).to_string()
+            } else {
+                color::Fg(color::LightWhite).to_string()
+            };
             let mut bg = color::Bg(color::Reset).to_string();
 
             if index == self.selection {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -187,7 +187,11 @@ impl<'a> Interface<'a> {
                     command,
                     &self.input.command,
                     width,
-                    color::Fg(color::Green).to_string(),
+                    if self.settings.lightmode {
+                        color::Fg(color::Blue).to_string()
+                    } else {
+                        color::Fg(color::Green).to_string()
+                    },
                     fg,
                     self.debug
                 )

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -130,7 +130,11 @@ impl<'a> Interface<'a> {
         write!(
             screen,
             "{}{}{}$ {}",
-            color::Fg(color::LightWhite).to_string(),
+            if self.settings.lightmode {
+                color::Fg(color::Black).to_string()
+            } else {
+                color::Fg(color::LightWhite).to_string()
+            },
             cursor::Goto(1, PROMPT_LINE_INDEX),
             clear::CurrentLine,
             self.input
@@ -190,7 +194,7 @@ impl<'a> Interface<'a> {
                     if self.settings.lightmode {
                         color::Fg(color::Blue).to_string()
                     } else {
-                        color::Fg(color::Green).to_string()
+                        color::Fg(color::Cyan).to_string()
                     },
                     fg,
                     self.debug

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub old_dir: Option<String>,
     pub append_to_histfile: bool,
     pub refresh_training_cache: bool,
+    pub lightmode: bool,
 }
 
 impl Default for Settings {
@@ -44,6 +45,7 @@ impl Default for Settings {
             refresh_training_cache: false,
             append_to_histfile: false,
             debug: false,
+            lightmode: false,
         }
     }
 }
@@ -243,6 +245,10 @@ impl Settings {
             _ => unreachable!(), // If all subcommands are defined above, anything else is unreachable!()
         }
 
+        settings.lightmode = match env::var_os("MCFLY_LIGHT") {
+            Some(_val) => true,
+            None => false
+        };
         settings
     }
 


### PR DESCRIPTION
(For Issue https://github.com/cantino/mcfly/issues/13)

When `MCFLY_LIGHT` is set, swap the relevant light and dark colors to make the text visible in a light terminal scheme. 

Useful for e.g. Solarized Light, Tango Light, or other common light terminal color schemes.

Feel free to change the colors themselves, I just went with something simple.