### PR TITLE
fix 'cat /dev/urandom' not closing

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -5,7 +5,7 @@ if [[ "$__MCFLY_LOADED" == "loaded" ]]; then
   return 0
 fi
 __MCFLY_LOADED="loaded"
-export MCFLY_SESSION_ID=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 24 | head -n 1)
+export MCFLY_SESSION_ID=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 24)
 export MCFLY_HISTORY=$(mktemp -t mcfly.XXXX)
 export HISTFILE="${HISTFILE:-$HOME/.bash_history}"
 


### PR DESCRIPTION
Fix #32 by letting head close the pipe after 24 characters which seems more stable