### PR TITLE
Implement Vim key scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,18 @@ To avoid McFly's UI messing up your scrollback history in iTerm2, make sure this
 
 <img src="/docs/iterm2.jpeg" alt="iterm2 UI instructions">
 
-## Light Mode
+## Settings
+A number of settings can be set via environment variables. To set a setting you should add the following snippets to your `~/.bash_profile`.
 
+### Light Mode
 To swap the color scheme for use in a light terminal, set the environment variable `MCFLY_LIGHT`.
-
-For example, add the following to your `~/.bash_profile`:
-
 ```bash
 export MCFLY_LIGHT=TRUE
+```
+### VIM Key Scheme
+By default Mcfly uses an `emacs` inspired key scheme. If you would like to switch to the `vim` inspired key scheme, set the environment variable `MCFLY_KEY_SCHEME`.
+```bash
+export MCFLY_KEY_SCHEME=vim
 ```
 
 ## Possible Future Features

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -408,16 +408,6 @@ impl<'a> Interface<'a> {
                     self.menu_mode = MenuMode::ConfirmDelete;
                 }
             }
-            Key::Ctrl(_c) => {
-                //                      self.debug(&mut screen, format!("Ctrl({})", c))
-            }
-            Key::Alt(_c) => {
-                //                      self.debug(&mut screen, format!("Alt({})", c))
-            }
-            Key::F(_c) => {
-                //                      self.debug(&mut screen, format!("F({})", c))
-            }
-            Key::Insert | Key::Null | Key::__IsNotComplete => {}
             _ => {}
         }
 
@@ -469,16 +459,6 @@ impl<'a> Interface<'a> {
                         self.menu_mode = MenuMode::ConfirmDelete;
                     }
                 }
-                Key::Ctrl(_c) => {
-                    //                      self.debug(&mut screen, format!("Ctrl({})", c))
-                }
-                Key::Alt(_c) => {
-                    //                      self.debug(&mut screen, format!("Alt({})", c))
-                }
-                Key::F(_c) => {
-                    //                      self.debug(&mut screen, format!("F({})", c))
-                }
-                Key::Insert | Key::Null | Key::__IsNotComplete => {}
                 _ => {}
             }
         } else {
@@ -531,16 +511,6 @@ impl<'a> Interface<'a> {
                         self.menu_mode = MenuMode::ConfirmDelete;
                     }
                 }
-                Key::Ctrl(_c) => {
-                    //                      self.debug(&mut screen, format!("Ctrl({})", c))
-                }
-                Key::Alt(_c) => {
-                    //                      self.debug(&mut screen, format!("Alt({})", c))
-                }
-                Key::F(_c) => {
-                    //                      self.debug(&mut screen, format!("F({})", c))
-                }
-                Key::Insert | Key::Null | Key::__IsNotComplete => {}
                 _ => {}
             }
         }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,6 +5,7 @@ use crate::fixed_length_grapheme_string::FixedLengthGraphemeString;
 use crate::history::Command;
 use crate::history_cleaner;
 use crate::settings::Settings;
+use crate::settings::KeyScheme;
 use std::io::{stdin, stdout, Write};
 use termion::color;
 use termion::event::Key;
@@ -22,6 +23,7 @@ pub struct Interface<'a> {
     debug: bool,
     run: bool,
     menu_mode: MenuMode,
+    in_vim_insert_mode: bool
 }
 
 pub struct SelectionResult {
@@ -41,9 +43,16 @@ pub enum MenuMode {
 }
 
 impl MenuMode {
-    fn text(&self) -> &str {
+    fn text(&self, interface: &Interface) -> &str {
         match *self {
-            MenuMode::Normal => "McFly | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete",
+            MenuMode::Normal => match interface.settings.key_scheme {
+                KeyScheme::Emacs => "McFly | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete",
+                KeyScheme::Vim => if interface.in_vim_insert_mode {
+                    "McFly (Vim) | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete        -- INSERT --"
+                } else {
+                    "McFly (Vim) | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete"
+                }
+            },
             MenuMode::ConfirmDelete => "Delete selected command from the history? (Y/N)",
         }
     }
@@ -72,6 +81,7 @@ impl<'a> Interface<'a> {
             debug: settings.debug,
             run: false,
             menu_mode: MenuMode::Normal,
+            in_vim_insert_mode: false
         }
     }
 
@@ -119,7 +129,7 @@ impl<'a> Interface<'a> {
             bg = self.menu_mode.bg(),
             cursor = cursor::Goto(1, INFO_LINE_INDEX),
             clear = clear::CurrentLine,
-            text = self.menu_mode.text(),
+            text = self.menu_mode.text(self),
             reset_bg = color::Bg(color::Reset).to_string(),
             width = width as usize
         ).unwrap();
@@ -310,85 +320,13 @@ impl<'a> Interface<'a> {
                     _ => {}
                 }
             } else {
-                match c.unwrap() {
-                    Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
-                        self.run = true;
-                        self.accept_selection();
-                        break;
-                    }
-                    Key::Char('\t') => {
-                        self.run = false;
-                        self.accept_selection();
-                        break;
-                    }
-                    Key::Ctrl('c')
-                    | Key::Ctrl('d')
-                    | Key::Ctrl('g')
-                    | Key::Ctrl('z')
-                    | Key::Esc
-                    | Key::Ctrl('r') => {
-                        self.run = false;
-                        self.input.clear();
-                        break;
-                    }
-                    Key::Ctrl('b') => self.input.move_cursor(Move::Backward),
-                    Key::Ctrl('f') => self.input.move_cursor(Move::Forward),
-                    Key::Ctrl('a') => self.input.move_cursor(Move::BOL),
-                    Key::Ctrl('e') => self.input.move_cursor(Move::EOL),
-                    Key::Ctrl('w') | Key::Alt('\x08') | Key::Alt('\x7f') => {
-                        self.input.delete(Move::BackwardWord);
-                        self.refresh_matches();
-                    }
-                    Key::Alt('d') => {
-                        self.input.delete(Move::ForwardWord);
-                        self.refresh_matches();
-                    }
-                    Key::Ctrl('v') => {
-                        self.debug = !self.debug;
-                    }
-                    Key::Alt('b') => self.input.move_cursor(Move::BackwardWord),
-                    Key::Alt('f') => self.input.move_cursor(Move::ForwardWord),
-                    Key::Left => self.input.move_cursor(Move::Backward),
-                    Key::Right => self.input.move_cursor(Move::Forward),
-                    Key::Up | Key::PageUp | Key::Ctrl('p') => self.move_selection(MoveSelection::Up),
-                    Key::Down | Key::PageDown | Key::Ctrl('n') => self.move_selection(MoveSelection::Down),
-                    Key::Ctrl('k') => {
-                        self.input.delete(Move::EOL);
-                        self.refresh_matches();
-                    }
-                    Key::Ctrl('u') => {
-                        self.input.delete(Move::BOL);
-                        self.refresh_matches();
-                    }
-                    Key::Backspace | Key::Ctrl('h') => {
-                        self.input.delete(Move::Backward);
-                        self.refresh_matches();
-                    }
-                    Key::Delete => {
-                        self.input.delete(Move::Forward);
-                        self.refresh_matches();
-                    }
-                    Key::Home => self.input.move_cursor(Move::BOL),
-                    Key::End => self.input.move_cursor(Move::EOL),
-                    Key::Char(c) => {
-                        self.input.insert(c);
-                        self.refresh_matches();
-                    }
-                    Key::F(2) => {
-                        if !self.matches.is_empty() {
-                            self.menu_mode = MenuMode::ConfirmDelete;
-                        }
-                    }
-                    Key::Ctrl(_c) => {
-                        //                      self.debug(&mut screen, format!("Ctrl({})", c))
-                    }
-                    Key::Alt(_c) => {
-                        //                      self.debug(&mut screen, format!("Alt({})", c))
-                    }
-                    Key::F(_c) => {
-                        //                      self.debug(&mut screen, format!("F({})", c))
-                    }
-                    Key::Insert | Key::Null | Key::__IsNotComplete => {}
+                let early_out = match self.settings.key_scheme {
+                    KeyScheme::Emacs => self.select_with_emacs_key_scheme(c.unwrap()),
+                    KeyScheme::Vim => self.select_with_vim_key_scheme(c.unwrap())
+                };
+
+                if early_out {
+                    break;
                 }
             }
 
@@ -398,6 +336,216 @@ impl<'a> Interface<'a> {
         }
 
         write!(screen, "{}{}", clear::All, cursor::Show).unwrap();
+    }
+
+    fn select_with_emacs_key_scheme(&mut self, k: Key) -> bool {
+        match k {
+            Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
+                self.run = true;
+                self.accept_selection();
+                return true;
+            }
+            Key::Char('\t') => {
+                self.run = false;
+                self.accept_selection();
+                return true;
+            }
+            Key::Ctrl('c')
+            | Key::Ctrl('d')
+            | Key::Ctrl('g')
+            | Key::Ctrl('z')
+            | Key::Esc
+            | Key::Ctrl('r') => {
+                self.run = false;
+                self.input.clear();
+                return true;
+            }
+            Key::Ctrl('b') => self.input.move_cursor(Move::Backward),
+            Key::Ctrl('f') => self.input.move_cursor(Move::Forward),
+            Key::Ctrl('a') => self.input.move_cursor(Move::BOL),
+            Key::Ctrl('e') => self.input.move_cursor(Move::EOL),
+            Key::Ctrl('w') | Key::Alt('\x08') | Key::Alt('\x7f') => {
+                self.input.delete(Move::BackwardWord);
+                self.refresh_matches();
+            }
+            Key::Alt('d') => {
+                self.input.delete(Move::ForwardWord);
+                self.refresh_matches();
+            }
+            Key::Ctrl('v') => {
+                self.debug = !self.debug;
+            }
+            Key::Alt('b') => self.input.move_cursor(Move::BackwardWord),
+            Key::Alt('f') => self.input.move_cursor(Move::ForwardWord),
+            Key::Left => self.input.move_cursor(Move::Backward),
+            Key::Right => self.input.move_cursor(Move::Forward),
+            Key::Up | Key::PageUp | Key::Ctrl('p') => self.move_selection(MoveSelection::Up),
+            Key::Down | Key::PageDown | Key::Ctrl('n') => self.move_selection(MoveSelection::Down),
+            Key::Ctrl('k') => {
+                self.input.delete(Move::EOL);
+                self.refresh_matches();
+            }
+            Key::Ctrl('u') => {
+                self.input.delete(Move::BOL);
+                self.refresh_matches();
+            }
+            Key::Backspace | Key::Ctrl('h') => {
+                self.input.delete(Move::Backward);
+                self.refresh_matches();
+            }
+            Key::Delete => {
+                self.input.delete(Move::Forward);
+                self.refresh_matches();
+            }
+            Key::Home => self.input.move_cursor(Move::BOL),
+            Key::End => self.input.move_cursor(Move::EOL),
+            Key::Char(c) => {
+                self.input.insert(c);
+                self.refresh_matches();
+            }
+            Key::F(2) => {
+                if !self.matches.is_empty() {
+                    self.menu_mode = MenuMode::ConfirmDelete;
+                }
+            }
+            Key::Ctrl(_c) => {
+                //                      self.debug(&mut screen, format!("Ctrl({})", c))
+            }
+            Key::Alt(_c) => {
+                //                      self.debug(&mut screen, format!("Alt({})", c))
+            }
+            Key::F(_c) => {
+                //                      self.debug(&mut screen, format!("F({})", c))
+            }
+            Key::Insert | Key::Null | Key::__IsNotComplete => {}
+            _ => {}
+        }
+
+        false
+    }
+
+    fn select_with_vim_key_scheme(&mut self, k: Key) -> bool {
+        if self.in_vim_insert_mode {
+            match k {
+                Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
+                    self.run = true;
+                    self.accept_selection();
+                    return true;
+                }
+                Key::Char('\t') => {
+                    self.run = false;
+                    self.accept_selection();
+                    return true;
+                }
+                Key::Ctrl('c')
+                | Key::Ctrl('g')
+                | Key::Ctrl('z')
+                | Key::Ctrl('r') => {
+                    self.run = false;
+                    self.input.clear();
+                    return true;
+                }
+                Key::Left => self.input.move_cursor(Move::Backward),
+                Key::Right => self.input.move_cursor(Move::Forward),
+                Key::Up | Key::PageUp | Key::Ctrl('u') => self.move_selection(MoveSelection::Up),
+                Key::Down | Key::PageDown | Key::Ctrl('d') => self.move_selection(MoveSelection::Down),
+                Key::Esc => self.in_vim_insert_mode = false,
+                Key::Backspace => {
+                    self.input.delete(Move::Backward);
+                    self.refresh_matches();
+                }
+                Key::Delete => {
+                    self.input.delete(Move::Forward);
+                    self.refresh_matches();
+                }
+                Key::Home => self.input.move_cursor(Move::BOL),
+                Key::End => self.input.move_cursor(Move::EOL),
+                Key::Char(c) => {
+                    self.input.insert(c);
+                    self.refresh_matches();
+                }
+                Key::F(2) => {
+                    if !self.matches.is_empty() {
+                        self.menu_mode = MenuMode::ConfirmDelete;
+                    }
+                }
+                Key::Ctrl(_c) => {
+                    //                      self.debug(&mut screen, format!("Ctrl({})", c))
+                }
+                Key::Alt(_c) => {
+                    //                      self.debug(&mut screen, format!("Alt({})", c))
+                }
+                Key::F(_c) => {
+                    //                      self.debug(&mut screen, format!("F({})", c))
+                }
+                Key::Insert | Key::Null | Key::__IsNotComplete => {}
+                _ => {}
+            }
+        } else {
+            match k {
+                Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
+                    self.run = true;
+                    self.accept_selection();
+                    return true;
+                }
+                Key::Char('\t') => {
+                    self.run = false;
+                    self.accept_selection();
+                    return true;
+                }
+                Key::Ctrl('c')
+                | Key::Ctrl('g')
+                | Key::Ctrl('z')
+                | Key::Esc
+                | Key::Char('q')
+                // TODO add ZZ as shortcut
+                | Key::Ctrl('r') => {
+                    self.run = false;
+                    self.input.clear();
+                    return true;
+                }
+                Key::Left | Key::Char('h') => self.input.move_cursor(Move::Backward),
+                Key::Right | Key::Char('l') => self.input.move_cursor(Move::Forward),
+                Key::Up | Key::PageUp | Key::Char('k') | Key::Ctrl('u') => self.move_selection(MoveSelection::Up),
+                Key::Down | Key::PageDown | Key::Char('j') | Key::Ctrl('d') => self.move_selection(MoveSelection::Down),
+                Key::Char('b') | Key::Char('e') => self.input.move_cursor(Move::BackwardWord),
+                Key::Char('w') => self.input.move_cursor(Move::ForwardWord),
+                Key::Char('0') | Key::Char('^') => self.input.move_cursor(Move::BOL),
+                Key::Char('$') => self.input.move_cursor(Move::EOL),
+                Key::Char('i') | Key::Char('a') => self.in_vim_insert_mode = true,
+                Key::Backspace => {
+                    self.input.delete(Move::Backward);
+                    self.refresh_matches();
+                }
+                Key::Delete | Key::Char('x') => {
+                    self.input.delete(Move::Forward);
+                    self.refresh_matches();
+                }
+                Key::Home => self.input.move_cursor(Move::BOL),
+                Key::End => self.input.move_cursor(Move::EOL),
+                Key::Char(_c) => {
+
+                }
+                Key::F(2) => {
+                    if !self.matches.is_empty() {
+                        self.menu_mode = MenuMode::ConfirmDelete;
+                    }
+                }
+                Key::Ctrl(_c) => {
+                    //                      self.debug(&mut screen, format!("Ctrl({})", c))
+                }
+                Key::Alt(_c) => {
+                    //                      self.debug(&mut screen, format!("Alt({})", c))
+                }
+                Key::F(_c) => {
+                    //                      self.debug(&mut screen, format!("F({})", c))
+                }
+                Key::Insert | Key::Null | Key::__IsNotComplete => {}
+                _ => {}
+            }
+        }
+
+        false
     }
 
     fn truncate_for_display(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,12 @@ pub enum Mode {
 }
 
 #[derive(Debug)]
+pub enum KeyScheme {
+    Emacs,
+    Vim
+}
+
+#[derive(Debug)]
 pub struct Settings {
     pub mode: Mode,
     pub debug: bool,
@@ -30,6 +36,7 @@ pub struct Settings {
     pub append_to_histfile: bool,
     pub refresh_training_cache: bool,
     pub lightmode: bool,
+    pub key_scheme: KeyScheme
 }
 
 impl Default for Settings {
@@ -47,6 +54,7 @@ impl Default for Settings {
             append_to_histfile: false,
             debug: false,
             lightmode: false,
+            key_scheme: KeyScheme::Emacs
         }
     }
 }
@@ -250,6 +258,11 @@ impl Settings {
             Some(_val) => true,
             None => false
         };
+        settings.key_scheme = match env::var("MCFLY_KEY_SCHEME").as_ref().map(String::as_ref) {
+            Ok("vim") => KeyScheme::Vim,
+            _ => KeyScheme::Emacs
+        };
+
         settings
     }
 


### PR DESCRIPTION
Implements a base set of Vim keybindings in McFly, enabled optionally by setting the `MCFLY_KEY_SCHEME` environment variable to `vim`. Closes #72.

Cheatsheet for Vim keys [here](https://devhints.io/vim) if you're not familiar. Only a subset has been implemented, some have been subtly simplified (i.e. `:q` is just `q`) and other functionality ommited entirely for the sake of simplicity (e.g. `3x`).

I'm not a Rust programmer sadly* so I appreciate any and all feedback, suggestions, code quality fixes, etc. you can provide. I've tried to do the simplest solutions I could think of for the most part so I'm more than happy to rearchitect parts in the 'Rust' way if there's better choices that could have been made!

\* This was mostly built by flailing around trying to get easier errors out of the compiler

Jamie