### PR TITLE
Add setting for number of results returned

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -60,8 +60,8 @@ PROMPT_COMMAND="mcfly_prompt_command;$PROMPT_COMMAND"
 #      render the search UI pre-filled with it.
 if [[ $- =~ .*i.* ]]; then
   if set -o | grep "vi " | grep -q on; then
-    bind "'\C-r': '\e0i#mcfly: \e\C-j mcfly search\C-j'"
+    bind "'\C-r': '\e0i#mcfly: \e\C-j mcfly search --results 10\C-j'"
   else
-    bind "'\C-r': '\C-amcfly: \e# mcfly search\C-j'"
+    bind "'\C-r': '\C-amcfly: \e# mcfly search --results 10\C-j'"
   fi
 fi

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -60,8 +60,8 @@ PROMPT_COMMAND="mcfly_prompt_command;$PROMPT_COMMAND"
 #      render the search UI pre-filled with it.
 if [[ $- =~ .*i.* ]]; then
   if set -o | grep "vi " | grep -q on; then
-    bind "'\C-r': '\e0i#mcfly: \e\C-j mcfly search --results 10\C-j'"
+    bind "'\C-r': '\e0i#mcfly: \e\C-j mcfly search\C-j'"
   else
-    bind "'\C-r': '\C-amcfly: \e# mcfly search --results 10\C-j'"
+    bind "'\C-r': '\C-amcfly: \e# mcfly search\C-j'"
   fi
 fi

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -68,7 +68,6 @@ impl MenuMode {
 const PROMPT_LINE_INDEX: u16 = 3;
 const INFO_LINE_INDEX: u16 = 1;
 const RESULTS_TOP_INDEX: u16 = 5;
-const RESULTS_TO_RETURN: u16 = 10;
 
 impl<'a> Interface<'a> {
     pub fn new(settings: &'a Settings, history: &'a History) -> Interface<'a> {
@@ -163,7 +162,7 @@ impl<'a> Interface<'a> {
             screen,
             "{}{}",
             cursor::Hide,
-            cursor::Goto(0, RESULTS_TOP_INDEX + RESULTS_TO_RETURN + 1)
+            cursor::Goto(0, RESULTS_TOP_INDEX + self.settings.results + 1)
         ).unwrap();
         screen.flush().unwrap();
     }
@@ -283,7 +282,7 @@ impl<'a> Interface<'a> {
     fn refresh_matches(&mut self) {
         self.selection = 0;
         self.matches = self.history
-            .find_matches(&self.input.command, RESULTS_TO_RETURN as i16);
+            .find_matches(&self.input.command, self.settings.results as i16);
     }
 
     fn select(&mut self) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,9 @@ use std::env;
 use std::path::PathBuf;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+use std::str::FromStr;
 use dirs::home_dir;
+
 
 #[derive(Debug)]
 pub enum Mode {
@@ -236,6 +238,11 @@ impl Settings {
                     settings.dir = dir.to_string();
                 } else {
                     settings.dir = env::var("PWD").unwrap_or_else(|err| panic!(format!("McFly error: Unable to determine current directory ({})", err)));
+                }
+                if let Some(results) = env::var("MCFLY_RESULTS").ok() {
+                    if let Ok(results) = u16::from_str(&results) {
+                        settings.results = results;
+                    }
                 }
                 if let Ok(results) = value_t!(search_matches.value_of("results"), u16) {
                     settings.results = results;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,6 +30,7 @@ pub struct Settings {
     pub mcfly_history: PathBuf,
     pub command: String,
     pub dir: String,
+    pub results: u16,
     pub when_run: Option<i64>,
     pub exit_code: Option<i32>,
     pub old_dir: Option<String>,
@@ -47,6 +48,7 @@ impl Default for Settings {
             session_id: String::new(),
             mcfly_history: PathBuf::new(),
             dir: String::new(),
+            results: 10,
             when_run: None,
             exit_code: None,
             old_dir: None,
@@ -124,6 +126,12 @@ impl Settings {
                     .long("dir")
                     .value_name("PATH")
                     .help("Directory where command was run")
+                    .takes_value(true))
+                .arg(Arg::with_name("results")
+                    .short("r")
+                    .long("results")
+                    .value_name("NUMBER")
+                    .help("Number of results to return")
                     .takes_value(true))
                 .arg(Arg::with_name("command")
                     .help("The command search term(s)")
@@ -228,6 +236,9 @@ impl Settings {
                     settings.dir = dir.to_string();
                 } else {
                     settings.dir = env::var("PWD").unwrap_or_else(|err| panic!(format!("McFly error: Unable to determine current directory ({})", err)));
+                }
+                if let Ok(results) = value_t!(search_matches.value_of("results"), u16) {
+                    settings.results = results;
                 }
                 if let Some(values) = search_matches.values_of("command") {
                     settings.command = values.collect::<Vec<_>>().join(" ");


### PR DESCRIPTION
As requested in issue #80
Moved number of results from hard-coded value to something user can change via 
`mcfly search --results` option, either directly or via `mcfly.bash` 