### PR TITLE
use c-m instead of c-j for return key

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -67,8 +67,8 @@ PROMPT_COMMAND="mcfly_prompt_command;$PROMPT_COMMAND"
 #      render the search UI pre-filled with it.
 if [[ $- =~ .*i.* ]]; then
   if set -o | grep "vi " | grep -q on; then
-    bind "'\C-r': '\e0i#mcfly: \e\C-j mcfly search\C-j'"
+    bind "'\C-r': '\e0i#mcfly: \e\C-m mcfly search\C-m'"
   else
-    bind "'\C-r': '\C-amcfly: \e# mcfly search\C-j'"
+    bind "'\C-r': '\C-amcfly: \e# mcfly search\C-m'"
   fi
 fi


### PR DESCRIPTION
The latter key is less likely to be rebound.

To avoid all these binding conflicts, one could think about a function `f` and a binding `bind -x "'\C-r': f"`instead