### PR TITLE
Do not set HISTCONTROL if it is already set

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -27,7 +27,7 @@ if [ -z "$MCFLY_PATH" ]; then
 fi
 
 # Ignore commands with a leading space
-export HISTCONTROL="ignorespace"
+export HISTCONTROL="${HISTCONTROL:-ignorespace}"
 
 # Append new history items to .bash_history
 shopt -s histappend


### PR DESCRIPTION
This depends on #105 (and fixes for `bash <4`) to some extent: If HISTCONTROL is set in such a way that `ignorespace` is not implied, ` #mcfly:` debris will pollute history. This is not as bad as it seems, becuase it is still be possible for users to create this issue by setting a bad `HISTCONTROL` after loading `mcfly.bash` in their `.bashrc`.

Otherwise, checks can be added for specific `$HISTCONTROL` values. In my case, my `ignoreboth` (which implies `ignorespace`) was being overwritten.