### PR TITLE
Remove emulate -L zsh as it seems unneeded and breaks some zsh features

### DIFF
--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -9,8 +9,6 @@ if [[ "$__MCFLY_LOADED" == "loaded" ]]; then
 fi
 __MCFLY_LOADED="loaded"
 
-emulate -L zsh
-
 # Ensure HISTFILE exists.
 export HISTFILE="${HISTFILE:-$HOME/.zsh_history}"
 if [[ ! -r "${HISTFILE}" ]]; then


### PR DESCRIPTION
Should fix #116 and #91.