### PR TITLE
Don't create a tarbomb

### DIFF
--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -26,8 +26,7 @@ main() {
     cp mcfly.zsh $stage/
     cp mcfly.fish $stage/
 
-    cd $stage
-    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
+    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz $stage
     cd $src
 
     rm -rf $stage


### PR DESCRIPTION
tarbomb (archive without folder) is generaly a bad practice.

Instead of:

- mcfly
- mcfly.bash
- mcfly.fish
- mcfly.zsh

this will create:

- mycfly
  - mcfly
  - mcfly.bash
  - mcfly.fish
  - mcfly.zsh

I'm not sure of all impact of it (for hombrew for example).