### PR TITLE
Minor lint fixes

### DIFF
--- a/dev.bash
+++ b/dev.bash
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Build mcfly and run a dev environment bash for local mcfly testing
 
-this_dir=$(cd `dirname "$0"`; pwd)
+if ! this_dir=$(cd "$(dirname "$0")" && pwd); then
+    exit $?
+fi
 
 rm -f target/debug/mcfly
 rm -rf target/debug/deps/mcfly-*

--- a/src/command_input.rs
+++ b/src/command_input.rs
@@ -1,4 +1,3 @@
-use core::mem;
 use std::fmt;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -103,7 +102,7 @@ impl CommandInput {
                     }
                 }
 
-                mem::replace(&mut self.command, new_command);
+                self.command = new_command;
                 self.recompute_caches();
             }
             Move::Forward => {
@@ -117,7 +116,7 @@ impl CommandInput {
                     }
                 }
 
-                mem::replace(&mut self.command, new_command);
+                self.command = new_command;
                 self.recompute_caches();
             }
             Move::EOL => {
@@ -131,7 +130,7 @@ impl CommandInput {
                     }
                 }
 
-                mem::replace(&mut self.command, new_command);
+                self.command = new_command;
                 self.recompute_caches();
                 self.move_cursor(Move::EOL);
             }
@@ -146,7 +145,7 @@ impl CommandInput {
                     }
                 }
 
-                mem::replace(&mut self.command, new_command);
+                self.command = new_command;
                 self.recompute_caches();
                 self.move_cursor(Move::BOL);
             }
@@ -163,7 +162,7 @@ impl CommandInput {
                     }
                 }
 
-                mem::replace(&mut self.command, new_command);
+                self.command = new_command;
                 self.recompute_caches();
             }
             Move::BackwardWord => {
@@ -183,7 +182,7 @@ impl CommandInput {
                     }
                 }
 
-                mem::replace(&mut self.command, new_command);
+                self.command = new_command;
                 self.recompute_caches();
                 let new_cursor_pos = self.cursor - removed_characters;
                 self.move_cursor(Move::Exact(new_cursor_pos));
@@ -208,7 +207,7 @@ impl CommandInput {
                 new_command.push(c);
             }
         }
-        mem::replace(&mut self.command, new_command);
+        self.command = new_command;
         self.recompute_caches();
         self.move_cursor(Move::Forward);
     }

--- a/src/history/db_extensions.rs
+++ b/src/history/db_extensions.rs
@@ -31,10 +31,5 @@ pub fn add_db_functions(db: &Connection) {
 
         Ok(network.output(&features))
     })
-    .unwrap_or_else(|err| {
-        panic!(format!(
-            "McFly error: Successful create_scalar_function ({})",
-            err
-        ))
-    });
+    .unwrap_or_else(|err| panic!("McFly error: Successful create_scalar_function ({})", err));
 }

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -136,7 +136,7 @@ impl History {
                                           (":selected", &selected),
                                           (":dir", &dir.to_owned()),
                                           (":old_dir", &old_dir.to_owned()),
-                                      ]).unwrap_or_else(|err| panic!(format!("McFly error: Insert into commands to work ({})", err)));
+                                      ]).unwrap_or_else(|err| panic!("McFly error: Insert into commands to work ({})", err));
     }
 
     fn determine_if_selected_from_ui(&self, command: &str, session_id: &str, dir: &str) -> bool {
@@ -154,10 +154,10 @@ impl History {
                 ],
             )
             .unwrap_or_else(|err| {
-                panic!(format!(
+                panic!(
                     "McFly error: DELETE from selected_commands to work ({})",
                     err
-                ))
+                )
             });
 
         // Delete any other pending selected commands for this session -- they must have been aborted or edited.
@@ -167,10 +167,10 @@ impl History {
                 &[(":session_id", &session_id.to_owned())],
             )
             .unwrap_or_else(|err| {
-                panic!(format!(
+                panic!(
                     "McFly error: DELETE from selected_commands to work ({})",
                     err
-                ))
+                )
             });
 
         rows_affected > 0
@@ -182,7 +182,7 @@ impl History {
                                           (":cmd", &command.to_owned()),
                                           (":session_id", &session_id.to_owned()),
                                           (":dir", &dir.to_owned())
-                                      ]).unwrap_or_else(|err| panic!(format!("McFly error: Insert into selected_commands to work ({})", err)));
+                                      ]).unwrap_or_else(|err| panic!("McFly error: Insert into selected_commands to work ({})", err));
     }
 
     // Update historical paths in our database if a directory has been renamed or moved.
@@ -254,12 +254,12 @@ impl History {
         let mut statement = self
             .connection
             .prepare(query)
-            .unwrap_or_else(|err| panic!(format!("McFly error: Prepare to work ({})", err)));
+            .unwrap_or_else(|err| panic!("McFly error: Prepare to work ({})", err));
         let command_iter = statement
             .query_map_named(&[(":like", &like_query), (":limit", &num)], |row| {
-                let text: String = row.get_checked(1).unwrap_or_else(|err| {
-                    panic!(format!("McFly error: cmd to be readable ({})", err))
-                });
+                let text: String = row
+                    .get_checked(1)
+                    .unwrap_or_else(|err| panic!("McFly error: cmd to be readable ({})", err));
                 let lowercase_text = text.to_lowercase();
                 let lowercase_cmd = cmd.to_lowercase();
 
@@ -292,96 +292,81 @@ impl History {
                 };
 
                 Command {
-                    id: row.get_checked(0).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: id to be readable ({})", err))
-                    }),
+                    id: row
+                        .get_checked(0)
+                        .unwrap_or_else(|err| panic!("McFly error: id to be readable ({})", err)),
                     cmd: text,
                     cmd_tpl: row.get_checked(2).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: cmd_tpl to be readable ({})", err))
+                        panic!("McFly error: cmd_tpl to be readable ({})", err)
                     }),
                     session_id: row.get_checked(3).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: session_id to be readable ({})", err))
+                        panic!("McFly error: session_id to be readable ({})", err)
                     }),
                     when_run: row.get_checked(4).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: when_run to be readable ({})", err))
+                        panic!("McFly error: when_run to be readable ({})", err)
                     }),
                     exit_code: row.get_checked(5).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: exit_code to be readable ({})", err))
+                        panic!("McFly error: exit_code to be readable ({})", err)
                     }),
                     selected: row.get_checked(6).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: selected to be readable ({})", err))
+                        panic!("McFly error: selected to be readable ({})", err)
                     }),
-                    dir: row.get_checked(7).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: dir to be readable ({})", err))
-                    }),
-                    rank: row.get_checked(8).unwrap_or_else(|err| {
-                        panic!(format!("McFly error: rank to be readable ({})", err))
-                    }),
+                    dir: row
+                        .get_checked(7)
+                        .unwrap_or_else(|err| panic!("McFly error: dir to be readable ({})", err)),
+                    rank: row
+                        .get_checked(8)
+                        .unwrap_or_else(|err| panic!("McFly error: rank to be readable ({})", err)),
                     match_bounds: bounds,
                     features: Features {
                         age_factor: row.get_checked(9).unwrap_or_else(|err| {
-                            panic!(format!("McFly error: age_factor to be readable ({})", err))
+                            panic!("McFly error: age_factor to be readable ({})", err)
                         }),
                         length_factor: row.get_checked(10).unwrap_or_else(|err| {
-                            panic!(format!(
-                                "McFly error: length_factor to be readable ({})",
-                                err
-                            ))
+                            panic!("McFly error: length_factor to be readable ({})", err)
                         }),
                         exit_factor: row.get_checked(11).unwrap_or_else(|err| {
-                            panic!(format!("McFly error: exit_factor to be readable ({})", err))
+                            panic!("McFly error: exit_factor to be readable ({})", err)
                         }),
                         recent_failure_factor: row.get_checked(12).unwrap_or_else(|err| {
-                            panic!(format!(
+                            panic!(
                                 "McFly error: recent_failure_factor to be readable ({})",
                                 err
-                            ))
+                            )
                         }),
                         selected_dir_factor: row.get_checked(13).unwrap_or_else(|err| {
-                            panic!(format!(
-                                "McFly error: selected_dir_factor to be readable ({})",
-                                err
-                            ))
+                            panic!("McFly error: selected_dir_factor to be readable ({})", err)
                         }),
                         dir_factor: row.get_checked(14).unwrap_or_else(|err| {
-                            panic!(format!("McFly error: dir_factor to be readable ({})", err))
+                            panic!("McFly error: dir_factor to be readable ({})", err)
                         }),
                         overlap_factor: row.get_checked(15).unwrap_or_else(|err| {
-                            panic!(format!(
-                                "McFly error: overlap_factor to be readable ({})",
-                                err
-                            ))
+                            panic!("McFly error: overlap_factor to be readable ({})", err)
                         }),
                         immediate_overlap_factor: row.get_checked(16).unwrap_or_else(|err| {
-                            panic!(format!(
+                            panic!(
                                 "McFly error: immediate_overlap_factor to be readable ({})",
                                 err
-                            ))
+                            )
                         }),
                         selected_occurrences_factor: row.get_checked(17).unwrap_or_else(|err| {
-                            panic!(format!(
+                            panic!(
                                 "McFly error: selected_occurrences_factor to be readable ({})",
                                 err
-                            ))
+                            )
                         }),
                         occurrences_factor: row.get_checked(18).unwrap_or_else(|err| {
-                            panic!(format!(
-                                "McFly error: occurrences_factor to be readable ({})",
-                                err
-                            ))
+                            panic!("McFly error: occurrences_factor to be readable ({})", err)
                         }),
                     },
                 }
             })
-            .unwrap_or_else(|err| panic!(format!("McFly error: Query Map to work ({})", err)));
+            .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
 
         let mut names = Vec::new();
         for result in command_iter {
             names.push(result.unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Unable to load command from DB ({})",
-                    err
-                ))
+                panic!("McFly error: Unable to load command from DB ({})", err)
             }));
         }
 
@@ -438,12 +423,7 @@ impl History {
 
         self.connection
             .execute("DROP TABLE IF EXISTS temp.contextual_commands;", NO_PARAMS)
-            .unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Removal of temp table to work ({})",
-                    err
-                ))
-            });
+            .unwrap_or_else(|err| panic!("McFly error: Removal of temp table to work ({})", err));
 
         let (mut when_run_min, when_run_max): (f64, f64) = self
             .connection
@@ -452,7 +432,7 @@ impl History {
                 NO_PARAMS,
                 |row| (row.get(0), row.get(1)),
             )
-            .unwrap_or_else(|err| panic!(format!("McFly error: Query to work ({})", err)));
+            .unwrap_or_else(|err| panic!("McFly error: Query to work ({})", err));
 
         if (when_run_min - when_run_max).abs() < std::f64::EPSILON {
             when_run_min -= 60.0 * 60.0;
@@ -553,10 +533,10 @@ impl History {
                 (":last_commands1", &last_commands[1].to_owned()),
                 (":last_commands2", &last_commands[2].to_owned()),
                 (":start_time", &start_time.unwrap_or(0).to_owned()),
-                (":end_time", &end_time.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!(format!("McFly error: Time went backwards ({})", err))).as_secs() as i64).to_owned()),
-                (":now", &now.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!(format!("McFly error: Time went backwards ({})", err))).as_secs() as i64).to_owned()),
+                (":end_time", &end_time.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err)).as_secs() as i64).to_owned()),
+                (":now", &now.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err)).as_secs() as i64).to_owned()),
                 (":min_id", &min_id)
-            ]).unwrap_or_else(|err| panic!(format!("McFly error: Creation of temp table to work ({})", err)));
+            ]).unwrap_or_else(|err| panic!("McFly error: Creation of temp table to work ({})", err));
 
         self.connection
             .execute(
@@ -567,12 +547,7 @@ impl History {
                                     selected_occurrences_factor, occurrences_factor);",
                 NO_PARAMS,
             )
-            .unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Ranking of temp table to work ({})",
-                    err
-                ))
-            });
+            .unwrap_or_else(|err| panic!("McFly error: Ranking of temp table to work ({})", err));
 
         self.connection
             .execute(
@@ -580,10 +555,10 @@ impl History {
                 NO_PARAMS,
             )
             .unwrap_or_else(|err| {
-                panic!(format!(
+                panic!(
                     "McFly error: Creation of index on temp table to work ({})",
                     err
-                ))
+                )
             });
 
         // println!("Seconds: {}", (beginning_of_execution.elapsed().as_secs() as f64) + (beginning_of_execution.elapsed().subsec_nanos() as f64 / 1000_000_000.0));
@@ -634,7 +609,7 @@ impl History {
 
         let command_iter: MappedRows<_> = statement
             .query_map_named(params, closure)
-            .unwrap_or_else(|err| panic!(format!("McFly error: Query Map to work ({})", err)));
+            .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
 
         let mut vec = Vec::new();
         for result in command_iter {
@@ -669,10 +644,10 @@ impl History {
                 &[(":command", &command)],
             )
             .unwrap_or_else(|err| {
-                panic!(format!(
+                panic!(
                     "McFly error: DELETE from selected_commands to work ({})",
                     err
-                ))
+                )
             });
 
         self.connection
@@ -680,12 +655,7 @@ impl History {
                 "DELETE FROM commands WHERE cmd = :command",
                 &[(":command", &command)],
             )
-            .unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: DELETE from commands to work ({})",
-                    err
-                ))
-            });
+            .unwrap_or_else(|err| panic!("McFly error: DELETE from commands to work ({})", err));
     }
 
     pub fn update_paths(&self, old_path: &str, new_path: &str, print_output: bool) {
@@ -710,7 +680,7 @@ impl History {
                     (":new_dir", &normalized_new_path),
                     (":length", &(normalized_old_path.chars().count() as u32 + 1)),
                 ])
-                .unwrap_or_else(|err| panic!(format!("McFly error: dir UPDATE to work ({})", err)));
+                .unwrap_or_else(|err| panic!("McFly error: dir UPDATE to work ({})", err));
 
             old_dir_update_statement
                 .execute_named(&[
@@ -719,9 +689,7 @@ impl History {
                     (":new_dir", &normalized_new_path),
                     (":length", &(normalized_old_path.chars().count() as u32 + 1)),
                 ])
-                .unwrap_or_else(|err| {
-                    panic!(format!("McFly error: old_dir UPDATE to work ({})", err))
-                });
+                .unwrap_or_else(|err| panic!("McFly error: old_dir UPDATE to work ({})", err));
 
             if print_output {
                 println!(
@@ -738,9 +706,9 @@ impl History {
         print!(
             "McFly: Importing shell history for the first time. This may take a minute or two..."
         );
-        io::stdout().flush().unwrap_or_else(|err| {
-            panic!(format!("McFly error: STDOUT flush should work ({})", err))
-        });
+        io::stdout()
+            .flush()
+            .unwrap_or_else(|err| panic!("McFly error: STDOUT flush should work ({})", err));
 
         // Load this first to make sure it works before we create the DB.
         let commands =
@@ -782,12 +750,12 @@ impl History {
                       dir TEXT NOT NULL \
                   ); \
                   CREATE INDEX selected_command_session_cmds ON selected_commands (session_id, cmd);"
-        ).unwrap_or_else(|err| panic!(format!("McFly error: Unable to initialize history db ({})", err)));
+        ).unwrap_or_else(|err| panic!("McFly error: Unable to initialize history db ({})", err));
 
         {
             let mut statement = connection
                 .prepare("INSERT INTO commands (cmd, cmd_tpl, session_id, when_run, exit_code, selected) VALUES (:cmd, :cmd_tpl, :session_id, :when_run, :exit_code, :selected)")
-                .unwrap_or_else(|err| panic!(format!("McFly error: Unable to prepare insert ({})", err)));
+                .unwrap_or_else(|err| panic!("McFly error: Unable to prepare insert ({})", err));
             for command in commands {
                 if !IGNORED_COMMANDS.contains(&command.command.as_str()) {
                     let simplified_command = SimplifiedCommand::new(&command.command, true);
@@ -801,9 +769,7 @@ impl History {
                                 (":exit_code", &0),
                                 (":selected", &0),
                             ])
-                            .unwrap_or_else(|err| {
-                                panic!(format!("McFly error: Insert to work ({})", err))
-                            });
+                            .unwrap_or_else(|err| panic!("McFly error: Insert to work ({})", err));
                     }
                 }
             }
@@ -820,12 +786,8 @@ impl History {
     }
 
     fn from_db_path(path: PathBuf) -> History {
-        let connection = Connection::open(path).unwrap_or_else(|err| {
-            panic!(format!(
-                "McFly error: Unable to open history database ({})",
-                err
-            ))
-        });
+        let connection = Connection::open(path)
+            .unwrap_or_else(|err| panic!("McFly error: Unable to open history database ({})", err));
         db_extensions::add_db_functions(&connection);
         History {
             connection,

--- a/src/history/schema.rs
+++ b/src/history/schema.rs
@@ -19,7 +19,7 @@ pub fn migrate(connection: &Connection) {
             NO_PARAMS,
             |row| row.get(0),
         )
-        .unwrap_or_else(|err| panic!(format!("McFly error: Query to work ({})", err)))
+        .unwrap_or_else(|err| panic!("McFly error: Query to work ({})", err))
         .unwrap_or(0);
 
     if current_version < CURRENT_SCHEMA_VERSION {
@@ -27,9 +27,9 @@ pub fn migrate(connection: &Connection) {
             "McFly: Upgrading McFly DB to version {}, please wait...",
             CURRENT_SCHEMA_VERSION
         );
-        io::stdout().flush().unwrap_or_else(|err| {
-            panic!(format!("McFly error: STDOUT flush should work ({})", err))
-        });
+        io::stdout()
+            .flush()
+            .unwrap_or_else(|err| panic!("McFly error: STDOUT flush should work ({})", err));
     }
 
     if current_version < 1 {
@@ -38,23 +38,18 @@ pub fn migrate(connection: &Connection) {
                 "ALTER TABLE commands ADD COLUMN cmd_tpl TEXT; UPDATE commands SET cmd_tpl = '';",
             )
             .unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Unable to add cmd_tpl to commands ({})",
-                    err
-                ))
+                panic!("McFly error: Unable to add cmd_tpl to commands ({})", err)
             });
 
         let mut statement = connection
             .prepare("UPDATE commands SET cmd_tpl = :cmd_tpl WHERE id = :id")
-            .unwrap_or_else(|err| {
-                panic!(format!("McFly error: Unable to prepare update ({})", err))
-            });
+            .unwrap_or_else(|err| panic!("McFly error: Unable to prepare update ({})", err));
 
         for (id, cmd) in cmd_strings(connection) {
             let simplified_command = SimplifiedCommand::new(cmd.as_str(), true);
             statement
                 .execute_named(&[(":cmd_tpl", &simplified_command.result), (":id", &id)])
-                .unwrap_or_else(|err| panic!(format!("McFly error: Insert to work ({})", err)));
+                .unwrap_or_else(|err| panic!("McFly error: Insert to work ({})", err));
         }
     }
 
@@ -66,10 +61,10 @@ pub fn migrate(connection: &Connection) {
                  CREATE INDEX command_session_id ON commands (session_id);",
             )
             .unwrap_or_else(|err| {
-                panic!(format!(
+                panic!(
                     "McFly error: Unable to add session_id to commands ({})",
                     err
-                ))
+                )
             });
     }
 
@@ -87,12 +82,7 @@ pub fn migrate(connection: &Connection) {
             ALTER TABLE commands ADD COLUMN selected INTEGER; \
             UPDATE commands SET selected = 0;",
             )
-            .unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Unable to add selected_commands ({})",
-                    err
-                ))
-            });
+            .unwrap_or_else(|err| panic!("McFly error: Unable to add selected_commands ({})", err));
     }
 
     if current_version < CURRENT_SCHEMA_VERSION {
@@ -112,10 +102,10 @@ fn make_schema_versions_table(connection: &Connection) {
              CREATE UNIQUE INDEX IF NOT EXISTS schema_versions_index ON schema_versions (version);",
         )
         .unwrap_or_else(|err| {
-            panic!(format!(
+            panic!(
                 "McFly error: Unable to create schema_versions db table ({})",
                 err
-            ))
+            )
         });
 }
 
@@ -124,12 +114,9 @@ fn write_current_schema_version(connection: &Connection) {
         "INSERT INTO schema_versions (version, when_run) VALUES ({}, strftime('%s','now'))",
         CURRENT_SCHEMA_VERSION
     );
-    connection.execute_batch(&insert).unwrap_or_else(|err| {
-        panic!(format!(
-            "McFly error: Unable to update schema_versions ({})",
-            err
-        ))
-    });
+    connection
+        .execute_batch(&insert)
+        .unwrap_or_else(|err| panic!("McFly error: Unable to update schema_versions ({})", err));
 }
 
 fn cmd_strings(connection: &Connection) -> Vec<(i64, String)> {
@@ -137,7 +124,7 @@ fn cmd_strings(connection: &Connection) -> Vec<(i64, String)> {
     let mut statement = connection.prepare(query).unwrap();
     let command_iter = statement
         .query_map(NO_PARAMS, |row| (row.get(0), row.get(1)))
-        .unwrap_or_else(|err| panic!(format!("McFly error: Query Map to work ({})", err)));
+        .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
 
     let mut vec = Vec::new();
     for result in command_iter {

--- a/src/history_cleaner.rs
+++ b/src/history_cleaner.rs
@@ -17,10 +17,7 @@ pub fn clean(settings: &Settings, history: &History, command: &str) {
 
             // Clean up HISTFILE.
             let histfile = PathBuf::from(env::var("HISTFILE").unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Please ensure that HISTFILE is set ({})",
-                    err
-                ))
+                panic!("McFly error: Please ensure that HISTFILE is set ({})", err)
             }));
             shell_history::delete_lines(&histfile, settings.history_format, command)
         }
@@ -36,10 +33,10 @@ fn clean_temporary_files(mcfly_history: &PathBuf, history_format: HistoryFormat,
     let path = mcfly_history.as_path();
     if let Some(directory) = path.parent() {
         let expanded_path = fs::canonicalize(directory).unwrap_or_else(|err| {
-            panic!(format!(
+            panic!(
                 "McFly error: The contents of $MCFLY_HISTORY appear invalid ({})",
                 err
-            ))
+            )
         });
         let paths = fs::read_dir(&expanded_path).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,19 +24,14 @@ fn handle_addition(settings: &Settings) {
 
         if settings.append_to_histfile {
             let histfile = PathBuf::from(env::var("HISTFILE").unwrap_or_else(|err| {
-                panic!(format!(
-                    "McFly error: Please ensure that HISTFILE is set ({})",
-                    err
-                ))
+                panic!("McFly error: Please ensure that HISTFILE is set ({})", err)
             }));
             let command = shell_history::HistoryCommand::new(
                 &settings.command,
                 settings.when_run.unwrap_or(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap_or_else(|err| {
-                            panic!(format!("McFly error: Time went backwards ({})", err))
-                        })
+                        .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err))
                         .as_secs() as i64,
                 ),
                 settings.history_format,
@@ -75,9 +70,8 @@ fn handle_search(settings: &Settings) {
                 out.push('\n');
             }
 
-            fs::write(path, &out).unwrap_or_else(|err| {
-                panic!(format!("McFly error: unable to write to {}: {}", path, err))
-            });
+            fs::write(path, &out)
+                .unwrap_or_else(|err| panic!("McFly error: unable to write to {}: {}", path, err));
         } else {
             fake_typer::use_tiocsti(&cmd);
 

--- a/src/path_update_helpers.rs
+++ b/src/path_update_helpers.rs
@@ -4,18 +4,14 @@ use std::path::Path;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub fn normalize_path(incoming_path: &str) -> String {
-    let expanded_path = shellexpand::full(incoming_path).unwrap_or_else(|err| {
-        panic!(format!(
-            "McFly error: Unable to expand command path ({})",
-            err
-        ))
-    });
+    let expanded_path = shellexpand::full(incoming_path)
+        .unwrap_or_else(|err| panic!("McFly error: Unable to expand command path ({})", err));
 
     let current_dir = env::var("PWD").unwrap_or_else(|err| {
-        panic!(format!(
+        panic!(
             "McFly error: Unable to determine current directory ({})",
             err
-        ))
+        )
     });
     let current_dir_path = Path::new(&current_dir);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -243,9 +243,9 @@ impl Settings {
                     .unwrap_or_else(|err| {
                         if !settings.skip_environment_check
                         {
-                            panic!(format!(
+                            panic!(
                             "McFly error: Please ensure that MCFLY_SESSION_ID contains a random session ID ({})",
-                            err))
+                            err)
                         }
                         else {
                             std::string::String::new()
@@ -258,10 +258,10 @@ impl Settings {
                 .unwrap_or_else(|| {
                     env::var("MCFLY_HISTORY").unwrap_or_else(|err| {
                         if !settings.skip_environment_check {
-                            panic!(format!(
+                            panic!(
                                 "McFly error: Please ensure that MCFLY_HISTORY is set ({})",
                                 err
-                            ))
+                            )
                         } else {
                             std::string::String::new()
                         }
@@ -287,7 +287,7 @@ impl Settings {
                         SystemTime::now()
                             .duration_since(UNIX_EPOCH)
                             .unwrap_or_else(|err| {
-                                panic!(format!("McFly error: Time went backwards ({})", err))
+                                panic!("McFly error: Time went backwards ({})", err)
                             })
                             .as_secs() as i64,
                     ),
@@ -310,10 +310,10 @@ impl Settings {
                     settings.dir = dir.to_string();
                 } else {
                     settings.dir = env::var("PWD").unwrap_or_else(|err| {
-                        panic!(format!(
+                        panic!(
                             "McFly error: Unable to determine current directory ({})",
                             err
-                        ))
+                        )
                     });
                 }
 
@@ -348,10 +348,10 @@ impl Settings {
                     settings.dir = dir.to_string();
                 } else {
                     settings.dir = env::var("PWD").unwrap_or_else(|err| {
-                        panic!(format!(
+                        panic!(
                             "McFly error: Unable to determine current directory ({})",
                             err
-                        ))
+                        )
                     });
                 }
 

--- a/src/shell_history.rs
+++ b/src/shell_history.rs
@@ -39,16 +39,16 @@ fn has_leading_timestamp(line: &str) -> bool {
 
 pub fn history_file_path() -> PathBuf {
     let path = PathBuf::from(env::var("HISTFILE").unwrap_or_else(|err| {
-        panic!(format!(
+        panic!(
             "McFly error: Please ensure HISTFILE is set for your shell ({})",
             err
-        ))
+        )
     }));
     fs::canonicalize(&path).unwrap_or_else(|err| {
-        panic!(format!(
+        panic!(
             "McFly error: The contents of $HISTFILE appear invalid ({})",
             err
-        ))
+        )
     })
 }
 
@@ -210,12 +210,7 @@ pub fn append_history_entry(command: &HistoryCommand, path: &PathBuf, debug: boo
         .write(true)
         .append(true)
         .open(path)
-        .unwrap_or_else(|err| {
-            panic!(format!(
-                "McFly error: please make sure HISTFILE exists ({})",
-                err
-            ))
-        });
+        .unwrap_or_else(|err| panic!("McFly error: please make sure HISTFILE exists ({})", err));
 
     if debug {
         println!("McFly: Appended to file '{:?}': {}", &path, command);

--- a/src/training_cache.rs
+++ b/src/training_cache.rs
@@ -5,12 +5,8 @@ use std::fs::File;
 use std::path::PathBuf;
 
 pub fn write(data_set: &[(Features, bool)], cache_path: &PathBuf) {
-    let mut writer = Writer::from_path(cache_path).unwrap_or_else(|err| {
-        panic!(format!(
-            "McFly error: Expected to be able to write a CSV ({})",
-            err
-        ))
-    });
+    let mut writer = Writer::from_path(cache_path)
+        .unwrap_or_else(|err| panic!("McFly error: Expected to be able to write a CSV ({})", err));
     output_header(&mut writer);
 
     for (features, correct) in data_set {
@@ -22,18 +18,18 @@ pub fn read(cache_path: &PathBuf) -> Vec<(Features, bool)> {
     let mut data_set: Vec<(Features, bool)> = Vec::new();
 
     let mut reader = Reader::from_path(cache_path).unwrap_or_else(|err| {
-        panic!(format!(
+        panic!(
             "McFly error: Expected to be able to read from CSV ({})",
             err
-        ))
+        )
     });
 
     for result in reader.records() {
         let record = result.unwrap_or_else(|err| {
-            panic!(format!(
+            panic!(
                 "McFly error: Expected to be able to unwrap cached result ({})",
                 err
-            ))
+            )
         });
 
         let features = Features {
@@ -70,10 +66,10 @@ fn output_header(writer: &mut Writer<File>) {
             "occurrences_factor",
             "correct",
         ])
-        .unwrap_or_else(|err| panic!(format!("McFly error: Expected to write to CSV ({})", err)));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to write to CSV ({})", err));
     writer
         .flush()
-        .unwrap_or_else(|err| panic!(format!("McFly error: Expected to flush CSV ({})", err)));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to flush CSV ({})", err));
 }
 
 fn output_row(writer: &mut Writer<File>, features: &Features, correct: bool) {
@@ -95,8 +91,8 @@ fn output_row(writer: &mut Writer<File>, features: &Features, correct: bool) {
                 String::from("f")
             },
         ])
-        .unwrap_or_else(|err| panic!(format!("McFly error: Expected to write to CSV ({})", err)));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to write to CSV ({})", err));
     writer
         .flush()
-        .unwrap_or_else(|err| panic!(format!("McFly error: Expected to flush CSV ({})", err)));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to flush CSV ({})", err));
 }


### PR DESCRIPTION
Fixes some Rust warnings:
* `panic!(format!(...))` is redundant, as `panic!` supports formatting
* `mem::replace` expects its return value to be used, but it's dropped - I changed this to an assignment, but I'm not 100% sure if this is equivalent

Also fixes some "issues" in the Bash scripts, mostly reported by ShellCheck:
* it's good practice to quote variables, so I quoted the ones ShellCheck complained about
* there are some places where it complained about the exit code being suppressed, so I propagated it
  * it's not clear to me whether this is at all useful to you, as `set -e` and such isn't being used