### PR TITLE
WIP: Add newline support

### DIFF
--- a/dev.bash
+++ b/dev.bash
@@ -5,12 +5,15 @@ if ! this_dir=$(cd "$(dirname "$0")" && pwd); then
     exit $?
 fi
 
+MCFLY_BIN_PATH=`mktemp -d`
+ln -s $(readlink -f $(find target/debug/deps/mcfly-* -maxdepth 1 -type f | grep -v '\.d')) $MCFLY_BIN_PATH/mcfly
+
 rm -f target/debug/mcfly
 rm -rf target/debug/deps/mcfly-*
 cargo build
 # For some reason, to get line numbers in backtraces, we have to run the binary directly.
 HISTFILE=$HOME/.bash_history \
-  MCFLY_PATH=$(find target/debug/deps/mcfly-* -maxdepth 1 -type f | grep -v '\.d') \
+  PATH="$MCFLY_BIN_PATH:$PATH" \
   RUST_BACKTRACE=full \
   MCFLY_DEBUG=1 \
   exec /bin/bash --init-file "$this_dir/mcfly.bash" -i

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -21,8 +21,7 @@ MCFLY_SESSION_ID="$(dd if=/dev/urandom bs=256 count=1 2> /dev/null | env LC_ALL=
 export MCFLY_SESSION_ID
 
 # Find the binary
-MCFLY_PATH=${MCFLY_PATH:-$(which mcfly)}
-if [ -z "$MCFLY_PATH" ]; then
+if [ -z "$(which mcfly)" ]; then
   echo "Cannot find the mcfly binary, please make sure that mcfly is in your path before sourcing mcfly.bash."
   return 1
 fi
@@ -44,15 +43,11 @@ function mcfly_prompt_command {
     tail -n100 "${HISTFILE}" >| "${MCFLY_HISTORY}"
   fi
 
-  history -a "${MCFLY_HISTORY}" # Append history to $MCFLY_HISTORY.
-  # Run mcfly with the saved code. It will:
-  # * append commands to $HISTFILE, (~/.bash_history by default)
-  #   for backwards compatibility and to load in new terminal sessions;
-  # * find the text of the last command in $MCFLY_HISTORY and save it to the database.
-  $MCFLY_PATH add --exit ${exit_code} --append-to-histfile
-  # Clear the in-memory history and reload it from $MCFLY_HISTORY
-  # (to remove instances of '#mcfly: ' from the local session history).
-  history -cr "${MCFLY_HISTORY}"
+  # Run mcfly with the last history entry on stdin. It will:
+  # * Append the command to $HISTFILE, (~/.bash_history by default)
+  # * Parse out the command and and save it to the database.
+  HISTTIMEFORMAT="%s:" history 1 | mcfly add --exit $exit_code --command-from-stdin
+
   return ${exit_code} # Restore the original exit code by returning it.
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -200,6 +200,7 @@ impl<'a> Interface<'a> {
             self.selection = self.matches.len() - 1;
         }
 
+        let mut line_offset = 0;
         for (index, command) in self.matches.iter().enumerate() {
             let mut fg = if self.settings.lightmode {
                 color::Fg(color::Black).to_string()
@@ -228,24 +229,31 @@ impl<'a> Interface<'a> {
             }
 
             write!(screen, "{}{}", fg, bg).unwrap();
+            
+            let command_display = Interface::truncate_for_display(
+                command,
+                &self.input.command,
+                width,
+                highlight,
+                fg,
+                self.debug
+            );
 
-            write!(
-                screen,
-                "{}{}",
-                cursor::Goto(1, index as u16 + RESULTS_TOP_INDEX),
-                Interface::truncate_for_display(
-                    command,
-                    &self.input.command,
-                    width,
-                    highlight,
-                    fg,
-                    self.debug
+            let mut lines_count = 0;
+
+            for line in command_display.lines() {
+                write!(
+                    screen,
+                    "{}{}",
+                    cursor::Goto(1, RESULTS_TOP_INDEX + (line_offset as u16) + (lines_count as u16)),
+                    line
                 )
-            )
-            .unwrap();
+                .unwrap();
+                lines_count += 1;
+            }
 
             if command.last_run.is_some() {
-                write!(screen, "{}", cursor::Goto(width - 9, index as u16 + RESULTS_TOP_INDEX)).unwrap();
+                write!(screen, "{}", cursor::Goto(width - 9, RESULTS_TOP_INDEX + (line_offset as u16))).unwrap();
 
                 let duration = &format_duration(
                     Duration::minutes(
@@ -287,6 +295,8 @@ impl<'a> Interface<'a> {
 
             write!(screen, "{}", color::Bg(color::Reset)).unwrap();
             write!(screen, "{}", color::Fg(color::Reset)).unwrap();
+
+            line_offset += lines_count;
         }
         screen.flush().unwrap();
     }
@@ -590,7 +600,7 @@ impl<'a> Interface<'a> {
         width: u16,
         highlight_color: String,
         base_color: String,
-        debug: bool,
+        debug: bool
     ) -> String {
         let mut prev: usize = 0;
         let debug_space = if debug { 90 } else { 0 };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -159,6 +159,10 @@ impl Settings {
                     .value_name("PATH")
                     .help("The previous directory the user was in before running the command (default $OLDPWD)")
                     .takes_value(true))
+                .arg(Arg::with_name("command_from_stdin")
+                    .long("command-from-stdin")
+                    .help("Read the command from `history` (must have HISTTIMEFORMAT=\"%s:\") command piped in.")
+                    .conflicts_with("command"))
                 .arg(Arg::with_name("command")
                     .help("The command that was run (default last line of $MCFLY_HISTORY file)")
                     .value_name("COMMAND")
@@ -309,6 +313,7 @@ impl Settings {
                 if let Some(dir) = add_matches.value_of("directory") {
                     settings.dir = dir.to_string();
                 } else {
+                    // XXX: Why not just use std::env::current_dir here?
                     settings.dir = env::var("PWD").unwrap_or_else(|err| {
                         panic!(
                             "McFly error: Unable to determine current directory ({})",
@@ -325,6 +330,11 @@ impl Settings {
 
                 if let Some(commands) = add_matches.values_of("command") {
                     settings.command = commands.collect::<Vec<_>>().join(" ");
+                } else if add_matches.is_present("command_from_stdin") {
+                    let bash_history = shell_history::read_from_bash_stdin()
+                        .expect("Could not read from stdin");
+                    //ignore the other values for now
+                    settings.command = bash_history.command;
                 } else {
                     settings.command = shell_history::last_history_line(
                         &settings.mcfly_history,
@@ -344,6 +354,7 @@ impl Settings {
 
             ("search", Some(search_matches)) => {
                 settings.mode = Mode::Search;
+
                 if let Some(dir) = search_matches.value_of("directory") {
                     settings.dir = dir.to_string();
                 } else {

--- a/src/shell_history.rs
+++ b/src/shell_history.rs
@@ -1,10 +1,12 @@
 use crate::settings::HistoryFormat;
 use regex::Regex;
+use regex::RegexBuilder;
 use std::env;
 use std::fmt;
 use std::fs;
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::path::PathBuf;
@@ -219,6 +221,36 @@ pub fn append_history_entry(command: &HistoryCommand, path: &PathBuf, debug: boo
     if let Err(e) = writeln!(file, "{}", command) {
         eprintln!("Couldn't append to file '{}': {}", path.display(), e);
     }
+}
+
+pub struct BashHistoryLine {
+    pub idx: u32,
+    pub edited: bool,
+    pub timestamp: u64,
+    pub command: String,
+}
+
+pub fn read_from_bash_stdin() -> io::Result<BashHistoryLine> {
+    // See https://github.com/bminor/bash/blob/ce23728687ce9e584333367075c9deef413553fa/builtins/history.def#L386
+    // First is the history index left-padded with space
+    // then either ' ' or '*' depending if the entry has been edited
+    // then a space ''
+    // then the timestamp in HISTTIMEFORMAT, which should be "%s:"
+    // then the command
+    // then a newline
+    let bash_history_regex = RegexBuilder::new(r"^\s*(?P<idx>\d+)(?P<edit>[\* ]) (?P<timestamp>\d+):(?P<command>.*)\n$")
+        .case_insensitive(false)
+        .dot_matches_new_line(true)
+        .build().unwrap();
+    let mut full = String::new();
+    io::stdin().read_to_string(&mut full)?;
+    let matches = bash_history_regex.captures(&full).expect("History line did not match expected format");
+    Ok(BashHistoryLine{
+        idx: matches.name("idx").unwrap().as_str().parse().unwrap(),
+        edited: matches.name("edit").unwrap().as_str() == "*",
+        timestamp: matches.name("timestamp").unwrap().as_str().parse().unwrap(),
+        command: matches.name("command").unwrap().as_str().to_string(),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
So I've been working on #50 and it sort of feels like things are sprawling out more and more, and I wanted to both contribute what I'd done so far and get feedback before making more changes.

As it stands right now, this PR *does* correctly record commands-with-newline(s) into the database.

The first issue I ran into was that the search interface would not show newlines correctly. I believe I've fixed it, but I haven't tested it rigourously.

While developing, I noticed that the search was running the wrong version of mcfly (installed version in `.cargo/bin` rather than the development version in `target`) despite using `dev.bash`, because the history addendum uses `$MCFLY_PATH` whereas the bind command just calls `mcfly`. I was unable to wrassle the multi-level quoting into working correctly in the bind command with a variable substitution, so I instead removed `$MCFLY_PATH` and relied on `mcfly` calling the right binary. This may not be desireable.

In changing the way the command is read in from history, I cut out some of the code that wrote to a file, filtered, and wrote back out history to then be re-read by `history -cr`. I think for bash the best solution would involve no itermediary files, just the database and `history` calls.

There seems to be some logic for removing history entries starting with `#mcfly`, but I don't see that in my history anyway so I don't understand why it's there. As it is in this PR, that functionality is never used I think.

Let me know your thoughts.