### PR TITLE
Make ^d delete forward, the readline(5) default.

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -418,7 +418,6 @@ impl<'a> Interface<'a> {
                 return true;
             }
             Key::Ctrl('c')
-            | Key::Ctrl('d')
             | Key::Ctrl('g')
             | Key::Ctrl('z')
             | Key::Esc
@@ -460,7 +459,7 @@ impl<'a> Interface<'a> {
                 self.input.delete(Move::Backward);
                 self.refresh_matches();
             }
-            Key::Delete => {
+            Key::Delete | Key::Ctrl('d') => {
                 self.input.delete(Move::Forward);
                 self.refresh_matches();
             }


### PR DESCRIPTION
It can also send EOF if there's no more input, but this binding is more
useful and there's the others (^z, ^g, ESC) to do the same.

(end of commit message)

Wasn't sure if this was an oversight or intentional, but I find myself instinctively deleting and accidentally closing `mcfly`.