### PR TITLE
Run clippy-fix and rustfmt

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -130,7 +130,7 @@ impl History {
         self.connection.execute_named("INSERT INTO commands (cmd, cmd_tpl, session_id, when_run, exit_code, selected, dir, old_dir) VALUES (:cmd, :cmd_tpl, :session_id, :when_run, :exit_code, :selected, :dir, :old_dir)",
                                       &[
                                           (":cmd", &command.to_owned()),
-                                          (":cmd_tpl", &simplified_command.result.to_owned()),
+                                          (":cmd_tpl", &simplified_command.result),
                                           (":session_id", &session_id.to_owned()),
                                           (":when_run", &when_run.to_owned()),
                                           (":exit_code", &exit_code.to_owned()),
@@ -243,7 +243,7 @@ impl History {
             like_query.push_str(cmd);
         }
 
-        like_query.push_str("%");
+        like_query.push('%');
 
         let query = "SELECT id, cmd, cmd_tpl, session_id, when_run, exit_code, selected, dir, rank,
                               age_factor, length_factor, exit_factor, recent_failure_factor,
@@ -277,7 +277,7 @@ impl History {
                                     return true;
                                 }
 
-                                return false;
+                                false
                             })
                             .map(|m| m.0);
 
@@ -391,7 +391,7 @@ impl History {
                     let b_mod = 1.0 - b_len as f64 / (a_len + b_len) as f64;
 
                     PartialOrd::partial_cmp(&(b.rank + b_mod), &(a.rank + a_mod))
-                        .unwrap_or_else(|| Ordering::Equal)
+                        .unwrap_or(Ordering::Equal)
                 })
                 .collect()
         }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -245,7 +245,12 @@ impl<'a> Interface<'a> {
             .unwrap();
 
             if command.last_run.is_some() {
-                write!(screen, "{}", cursor::Goto(width - 9, index as u16 + RESULTS_TOP_INDEX)).unwrap();
+                write!(
+                    screen,
+                    "{}",
+                    cursor::Goto(width - 9, index as u16 + RESULTS_TOP_INDEX)
+                )
+                .unwrap();
 
                 let duration = &format_duration(
                     Duration::minutes(
@@ -257,7 +262,7 @@ impl<'a> Interface<'a> {
                     .unwrap(),
                 )
                 .to_string()
-                .split(" ")
+                .split(' ')
                 .take(2)
                 .map(|s| {
                     s.replace("years", "y")
@@ -417,11 +422,7 @@ impl<'a> Interface<'a> {
                 self.accept_selection();
                 return true;
             }
-            Key::Ctrl('c')
-            | Key::Ctrl('g')
-            | Key::Ctrl('z')
-            | Key::Esc
-            | Key::Ctrl('r') => {
+            Key::Ctrl('c') | Key::Ctrl('g') | Key::Ctrl('z') | Key::Esc | Key::Ctrl('r') => {
                 self.run = false;
                 self.input.clear();
                 return true;

--- a/src/path_update_helpers.rs
+++ b/src/path_update_helpers.rs
@@ -119,10 +119,7 @@ mod tests {
 
     #[test]
     fn normalize_path_works_with_tilda() {
-        assert_eq!(
-            normalize_path("~/"),
-            String::from(env::var("HOME").unwrap())
-        );
+        assert_eq!(normalize_path("~/"), env::var("HOME").unwrap());
         assert_eq!(
             normalize_path("~/foo"),
             PathBuf::from(env::var("HOME").unwrap())
@@ -143,10 +140,7 @@ mod tests {
                 .join("foo/baz")
                 .to_string_lossy()
         );
-        assert_eq!(
-            normalize_path("~/foo/bar/../.."),
-            String::from(env::var("HOME").unwrap())
-        );
+        assert_eq!(normalize_path("~/foo/bar/../.."), env::var("HOME").unwrap());
     }
 
     #[test]

--- a/src/shell_history.rs
+++ b/src/shell_history.rs
@@ -95,7 +95,7 @@ impl fmt::Display for HistoryCommand {
 pub fn full_history(path: &PathBuf, history_format: HistoryFormat) -> Vec<HistoryCommand> {
     match history_format {
         HistoryFormat::Bash | HistoryFormat::Zsh { .. } => {
-            let history_contents = read_ignoring_utf_errors(&path);
+            let history_contents = read_ignoring_utf_errors(path);
             let zsh_timestamp_and_duration_regex = Regex::new(r"^: \d+:\d+;").unwrap();
             let when = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -114,7 +114,7 @@ pub fn full_history(path: &PathBuf, history_format: HistoryFormat) -> Vec<Histor
             // newlines) and timestamps, ignoring the 'paths' field.
             let mut commands = Vec::new();
 
-            let history_contents = read_ignoring_utf_errors(&path);
+            let history_contents = read_ignoring_utf_errors(path);
 
             // Store command strings, and add them as HistoryCommand when we see the timestamp.
             let mut command = None;

--- a/src/simplified_command.rs
+++ b/src/simplified_command.rs
@@ -41,13 +41,11 @@ impl SimplifiedCommand {
                 "\"" => {
                     if escaped {
                         escaped = false;
-                    } else {
-                        if in_double_quote {
-                            in_double_quote = false;
-                            self.result.push_str("QUOTED");
-                        } else if !in_single_quote {
-                            in_double_quote = true;
-                        }
+                    } else if in_double_quote {
+                        in_double_quote = false;
+                        self.result.push_str("QUOTED");
+                    } else if !in_single_quote {
+                        in_double_quote = true;
                     }
                 }
                 "\'" => {

--- a/src/training_sample_generator.rs
+++ b/src/training_sample_generator.rs
@@ -67,8 +67,7 @@ impl<'a> TrainingSampleGenerator<'a> {
 
             // Get the features for this command at the time it was logged.
             if positive_examples <= negative_examples {
-                if let Some(our_command_index) =
-                    results.iter().position(|ref c| c.cmd.eq(&command.cmd))
+                if let Some(our_command_index) = results.iter().position(|c| c.cmd.eq(&command.cmd))
                 {
                     let what_should_have_been_first = &results[our_command_index];
                     data_set.push((what_should_have_been_first.features.clone(), true));


### PR DESCRIPTION
Ran `rustfmt` and fixed most clippy warnings. Theres two left:

```shell
error: name `BOL` contains a capitalized acronym
  --> src/command_input.rs:14:5
   |
14 |     BOL,
   |     ^^^ help: consider making the acronym lowercase, except the initial letter: `Bol`
   |
   = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `EOL` contains a capitalized acronym
  --> src/command_input.rs:15:5
   |
15 |     EOL,
   |     ^^^ help: consider making the acronym lowercase, except the initial letter: `Eol`
```

I can either turn that check off or fix it. Up to you @cantino 