### PR TITLE
Adding Emacs up/down motion to vi insert mode keybindings

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -56,9 +56,9 @@ impl MenuMode {
                 KeyScheme::Emacs => "McFly | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete",
                 KeyScheme::Vim => {
                     if interface.in_vim_insert_mode {
-                        "McFly (Vim-INSERT) | ESC - Norm | ⏎ - Run | TAB - Edit | F2 - Delete"
+                        "McFly (Ins) | ESC - Cmd  | ⏎ - Run | TAB - Edit | F2 - Delete"
                     } else {
-                        "McFly (Vim-NORMAL) | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete"
+                        "McFly (Cmd) | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete"
                     }
                 }
             },


### PR DESCRIPTION
Vim supports a few Emacs keybindings while in insert mode, one of them being `Ctrl-p` and `Ctrl-n` for up and down movements:
[vim insert.txt](http://vimdoc.sourceforge.net/htmldoc/insert.html#i_CTRL-X_CTRL-N). 

The vim help pages even shamelessly suggest a few useful remaps, including `Ctrl-p` and `Ctrl-n` for up/down movement: [vim tips.txt useful-mappings](https://vimhelp.org/tips.txt.html#useful-mappings). 

Hopefully I'm not the only vim user that likes using emacs motion keys while in insert mode and more people find it useful.