### PR TITLE
Make MCFLY_FUZZY a tuneable int

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 McFly replaces your default `ctrl-r` shell history search with an intelligent search engine that takes into account
 your working directory and the context of recently executed commands. McFly's suggestions are prioritized
 in real time with a small neural network.
- 
+
 TL;DR: an upgraded `ctrl-r` where history results make sense for what you're working on right now.
 
 ## Features
@@ -222,16 +222,16 @@ set -gx MCFLY_KEY_SCHEME vim
 ```
 
 ### Fuzzy Searching
-To enable fuzzy searching, set `MCFLY_FUZZY`.
+To enable fuzzy searching, set `MCFLY_FUZZY` to an integer. 0 is off; higher numbers weight toward shorter matches. Try a few values and [report what works best for you](https://github.com/cantino/mcfly/issues/183)!
 
 bash / zsh:
 ```bash
-export MCFLY_FUZZY=true
+export MCFLY_FUZZY=10
 ```
 
 fish:
 ```bash
-set -gx MCFLY_FUZZY true
+set -gx MCFLY_FUZZY 10
 ```
 
 ### Results Count

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ set -gx MCFLY_KEY_SCHEME vim
 ```
 
 ### Fuzzy Searching
-To enable fuzzy searching, set `MCFLY_FUZZY` to an integer. 0 is off; higher numbers weight toward shorter matches. Try a few values and [report what works best for you](https://github.com/cantino/mcfly/issues/183)!
+To enable fuzzy searching, set `MCFLY_FUZZY` to an integer. 0 is off; higher numbers weight toward shorter matches. Values in the 2-5 range get good results so far; try a few and [report what works best for you](https://github.com/cantino/mcfly/issues/183)!
 
 bash / zsh:
 ```bash

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -420,13 +420,16 @@ impl History {
                     let a_len = a.match_bounds[0].1 - a_start;
                     let b_len = b.match_bounds[0].1 - b_start;
 
-                    let a_mod = 1.0 - (a_start + a_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
-                    let b_mod = 1.0 - (b_start + b_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
+                    let a_mod =
+                        1.0 - (a_start + a_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
+                    let b_mod =
+                        1.0 - (b_start + b_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
 
                     PartialOrd::partial_cmp(
                         &(b.rank + b_mod * fuzzy as f64),
-                        &(a.rank + a_mod * fuzzy as f64))
-                        .unwrap_or(Ordering::Equal)
+                        &(a.rank + a_mod * fuzzy as f64),
+                    )
+                    .unwrap_or(Ordering::Equal)
                 })
                 .collect()
         }

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -395,22 +395,37 @@ impl History {
             names = names
                 .into_iter()
                 .sorted_by(|a, b| {
-                    // results are already sorted by rank, but with fuzzy mode we
-                    // need to prioritize shorter matches as well, and can only do
-                    // that at runtime. Each match's rank is weighted by the
-                    // inverse of its length (relative to both matches) to give
-                    // short but lower-ranked matches a chance to beat higher-
-                    // ranked but longer matches.
+                    // Fuzzy matches impose new ordering criteria on top of the
+                    // natural rank-based sorting: at the most basic level,
+                    // shorter and earlier matches are more likely to be
+                    // desired than longer or later matches -- even if they are
+                    // ranked a little lower.
+                    //
+                    // Each match is weighted by the inverse of its length plus
+                    // start position, relative to the total length + start of
+                    // both matches added together. This yields two complements
+                    // which always add up to 1 (e.g. 0.6 vs 0.4). If both
+                    // matches have the same length and start position, or if
+                    // those balance out exactly, the resulting weights will
+                    // both equal 0.5.
+                    //
+                    // The weights are multiplied by the configurable fuzzy
+                    // factor before being added to each result's original
+                    // rank. Factors > 1 are a "thumb on the scale" increasing
+                    // the likelihood of the weight flipping the outcome for
+                    // the originally lower-ranked result.
 
-                    let a_len = a.match_bounds[0].1 - a.match_bounds[0].0;
-                    let b_len = b.match_bounds[0].1 - b.match_bounds[0].0;
-                    let mut a_mod = 1.0 - a_len as f64 / (a_len + b_len) as f64;
-                    let mut b_mod = 1.0 - b_len as f64 / (a_len + b_len) as f64;
+                    let a_start = a.match_bounds[0].0;
+                    let b_start = b.match_bounds[0].0;
+                    let a_len = a.match_bounds[0].1 - a_start;
+                    let b_len = b.match_bounds[0].1 - b_start;
 
-                    if a_len > b_len { b_mod *= fuzzy as f64; }
-                    if b_len > a_len { a_mod *= fuzzy as f64; }
+                    let a_mod = 1.0 - (a_start + a_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
+                    let b_mod = 1.0 - (b_start + b_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
 
-                    PartialOrd::partial_cmp(&(b.rank + b_mod), &(a.rank + a_mod))
+                    PartialOrd::partial_cmp(
+                        &(b.rank + b_mod * fuzzy as f64),
+                        &(a.rank + a_mod * fuzzy as f64))
                         .unwrap_or(Ordering::Equal)
                 })
                 .collect()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -65,7 +65,7 @@ pub enum HistoryFormat {
 pub struct Settings {
     pub mode: Mode,
     pub debug: bool,
-    pub fuzzy: bool,
+    pub fuzzy: i16,
     pub session_id: String,
     pub mcfly_history: PathBuf,
     pub output_selection: Option<String>,
@@ -104,7 +104,7 @@ impl Default for Settings {
             refresh_training_cache: false,
             append_to_histfile: false,
             debug: false,
-            fuzzy: false,
+            fuzzy: 0,
             lightmode: false,
             key_scheme: KeyScheme::Emacs,
             history_format: HistoryFormat::Bash,
@@ -201,7 +201,7 @@ impl Settings {
                 .arg(Arg::with_name("fuzzy")
                     .short("f")
                     .long("fuzzy")
-                    .help("Fuzzy-find results instead of searching for contiguous strings"))
+                    .help("Fuzzy-find results. 0 is off, higher numbers weight toward shorter matches"))
                 .arg(Arg::with_name("delete_without_confirm")
                     .long("delete_without_confirm")
                     .help("Delete entry without confirm"))
@@ -404,8 +404,14 @@ impl Settings {
                     settings.results = results;
                 }
 
-                settings.fuzzy =
-                    search_matches.is_present("fuzzy") || env::var("MCFLY_FUZZY").is_ok();
+                if let Ok(fuzzy) = env::var("MCFLY_FUZZY") {
+                    if let Ok(fuzzy) = i16::from_str(&fuzzy) {
+                        settings.fuzzy = fuzzy;
+                    }
+                }
+                if let Ok(fuzzy) = value_t!(search_matches.value_of("fuzzy"), i16) {
+                    settings.fuzzy = fuzzy;
+                }
 
                 settings.delete_without_confirm = search_matches
                     .is_present("delete_without_confirm")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -407,7 +407,7 @@ impl Settings {
                 if let Ok(fuzzy) = env::var("MCFLY_FUZZY") {
                     if let Ok(fuzzy) = i16::from_str(&fuzzy) {
                         settings.fuzzy = fuzzy;
-                    } else {
+                    } else if fuzzy.to_lowercase() != "false" {
                         settings.fuzzy = 2;
                     }
                 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -201,7 +201,7 @@ impl Settings {
                 .arg(Arg::with_name("fuzzy")
                     .short("f")
                     .long("fuzzy")
-                    .help("Fuzzy-find results. 0 is off, higher numbers weight toward shorter matches"))
+                    .help("Fuzzy-find results. 0 is off; higher numbers weight shorter/earlier matches more. Try 2"))
                 .arg(Arg::with_name("delete_without_confirm")
                     .long("delete_without_confirm")
                     .help("Delete entry without confirm"))
@@ -407,10 +407,14 @@ impl Settings {
                 if let Ok(fuzzy) = env::var("MCFLY_FUZZY") {
                     if let Ok(fuzzy) = i16::from_str(&fuzzy) {
                         settings.fuzzy = fuzzy;
+                    } else {
+                        settings.fuzzy = 2;
                     }
                 }
                 if let Ok(fuzzy) = value_t!(search_matches.value_of("fuzzy"), i16) {
                     settings.fuzzy = fuzzy;
+                } else if search_matches.is_present("fuzzy") {
+                    settings.fuzzy = 2;
                 }
 
                 settings.delete_without_confirm = search_matches

--- a/src/training_sample_generator.rs
+++ b/src/training_sample_generator.rs
@@ -66,7 +66,7 @@ impl<'a> TrainingSampleGenerator<'a> {
             let results = history.find_matches(
                 &String::new(),
                 -1,
-                false,
+                0,
                 &crate::settings::ResultSort::Rank,
             );
 

--- a/src/training_sample_generator.rs
+++ b/src/training_sample_generator.rs
@@ -63,12 +63,8 @@ impl<'a> TrainingSampleGenerator<'a> {
             );
 
             // Load the entire match set.
-            let results = history.find_matches(
-                &String::new(),
-                -1,
-                0,
-                &crate::settings::ResultSort::Rank,
-            );
+            let results =
+                history.find_matches(&String::new(), -1, 0, &crate::settings::ResultSort::Rank);
 
             // Get the features for this command at the time it was logged.
             if positive_examples <= negative_examples {


### PR DESCRIPTION
Experimenting based on discussion in #183

No extra weight:
![fuzzy-factor-1](https://user-images.githubusercontent.com/3075455/139182155-d32fb972-25a7-4da2-8bb7-7a29495b90fb.png)

No elaboration needed, it's not great.

Shorter match weighted x2:
![fuzzy-factor-2](https://user-images.githubusercontent.com/3075455/139182157-42788830-dcde-45c6-82f1-e0267d2f0427.png)

Immediate improvement, with actual ssh commands at the top and most other sorting fairly reasonable. The `./target/relea[se/mcfly search]` match is ahead of `vi [sql.zsh]`, but I've definitely run the former several times in this directory (and the latter never).

Shorter match weighted x10:
![fuzzy-factor-10](https://user-images.githubusercontent.com/3075455/139182158-7d47bb68-ed7f-4882-aa94-86291226337e.png)

There's a point of diminishing returns here and 10 may be past it; `./target/relea[se/mcfly search]` is pushed way down, and even higher values (x20, x50) don't look much different.