### PR TITLE
Add zinit install method to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ When suggesting a command, McFly takes into consideration:
     ```
 1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` or restart your terminal emulator.
 
+### Install by [Zinit](https://github.com/zdharma-continuum/zinit)
+
+* Add below code to your zshrc.
+
+    ```zsh
+    zinit ice lucid wait"0a" from"gh-r" as"program" atload'eval "$(mcfly init zsh)"' 
+    zinit light cantino/mcfly 
+    ```
+* It will download mcfly and install for you.
+* `$(mcfly init zsh)` will be executed after prompt
+
 ## iTerm2
 
 To avoid McFly's UI messing up your scrollback history in iTerm2, make sure this option is unchecked:


### PR DESCRIPTION
Thanks for the awesome jobs.
I use zinit as the Zshell plugin manager. With the example below mcfly can be downloaded and installed automictically. Also I can enter the shell with feeling the delay cause running McFly delay.
Hoping this can help other guys.