### PR TITLE
use `command -v` instead of `which`

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -21,7 +21,7 @@ MCFLY_SESSION_ID="$(command dd if=/dev/urandom bs=256 count=1 2> /dev/null | LC_
 export MCFLY_SESSION_ID
 
 # Find the binary
-MCFLY_PATH=${MCFLY_PATH:-$(command which mcfly)}
+MCFLY_PATH=${MCFLY_PATH:-$(command -v mcfly)}
 if [ -z "$MCFLY_PATH" ]; then
   echo "Cannot find the mcfly binary, please make sure that mcfly is in your path before sourcing mcfly.bash."
   return 1

--- a/mcfly.fish
+++ b/mcfly.fish
@@ -20,7 +20,7 @@ end
 set -gx MCFLY_SESSION_ID (dd if=/dev/urandom bs=256 count=1 2>/dev/null | env LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 24)
 
 # Find the binary
-set -q MCFLY_PATH; or set -l MCFLY_PATH (command which mcfly)
+set -q MCFLY_PATH; or set -l MCFLY_PATH (command -v mcfly)
 if test -z "$MCFLY_PATH"; or test "$MCFLY_PATH" = "mcfly not found"
   echo "Cannot find the mcfly binary, please make sure that mcfly is in your path before sourcing mcfly.fish"
   exit 1

--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -20,7 +20,7 @@ fi
 export MCFLY_SESSION_ID=$(command dd if=/dev/urandom bs=256 count=1 2> /dev/null | LC_ALL=C command tr -dc 'a-zA-Z0-9' | command head -c 24)
 
 # Find the binary
-MCFLY_PATH=${MCFLY_PATH:-$(command which mcfly)}
+MCFLY_PATH=${MCFLY_PATH:-$(command -v mcfly)}
 if [[ -z "$MCFLY_PATH" || "$MCFLY_PATH" == "mcfly not found" ]]; then
   echo "Cannot find the mcfly binary, please make sure that mcfly is in your path before sourcing mcfly.zsh."
   return 1


### PR DESCRIPTION
which now outputs annoying deprecation notice in bash. In test, fish does the same but zsh does not--however it might? either way, `command v` works in zsh.