### PR TITLE
Automatically detect if Zsh extended history is used

### DIFF
--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -34,6 +34,13 @@ if [[ ! -f "${MCFLY_HISTORY}" ]]; then
   export MCFLY_HISTORY=$(command mktemp -t mcfly.XXXXXXXX)
 fi
 
+# Check if we need to use extended history
+if [[ -o extendedhistory ]]; then
+  export MCFLY_HISTORY_FORMAT="zsh-extended"
+else
+  export MCFLY_HISTORY_FORMAT="zsh"
+fi
+
 # Setup a function to be used by $PROMPT_COMMAND.
 function mcfly_prompt_command {
   local exit_code=$? # Record exit status of previous command.
@@ -49,7 +56,7 @@ function mcfly_prompt_command {
 
   # Run mcfly with the saved code. It fill find the text of the last command in $MCFLY_HISTORY and save it to the database.
   [ -n "$MCFLY_DEBUG" ] && echo "mcfly.zsh: Run mcfly add --exit ${exit_code}"
-  $MCFLY_PATH --history_format zsh add --exit ${exit_code}
+  $MCFLY_PATH --history_format $MCFLY_HISTORY_FORMAT add --exit ${exit_code}
   return ${exit_code} # Restore the original exit code by returning it.
 }
 precmd_functions+=(mcfly_prompt_command)
@@ -68,7 +75,7 @@ if [[ $- =~ .*i.* ]]; then
       echoti rmkx
       exec </dev/tty
       local mcfly_output=$(mktemp -t mcfly.output.XXXXXXXX)
-      $MCFLY_PATH --history_format zsh search -o "${mcfly_output}" "${LBUFFER}"
+      $MCFLY_PATH --history_format $MCFLY_HISTORY_FORMAT search -o "${mcfly_output}" "${LBUFFER}"
       echoti smkx
 
       # Interpret commandline/run requests from McFly

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -312,7 +312,7 @@ impl Settings {
                 extended_history: false,
             },
             Some("zsh-extended") => HistoryFormat::Zsh {
-                extended_history: true
+                extended_history: true,
             },
             Some("fish") => HistoryFormat::Fish,
             Some(format) => panic!("McFly error: unknown history format '{}'", format),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -141,7 +141,7 @@ impl Settings {
                 .takes_value(true))
             .arg(Arg::with_name("history_format")
                 .long("history_format")
-                .help("Shell history file format, 'bash', 'zsh', or 'fish' (defaults to 'bash')")
+                .help("Shell history file format, 'bash', 'zsh', 'zsh-extended' or 'fish' (defaults to 'bash')")
                 .value_name("FORMAT")
                 .takes_value(true))
             .subcommand(SubCommand::with_name("add")
@@ -156,9 +156,6 @@ impl Settings {
                 .arg(Arg::with_name("append_to_histfile")
                     .long("append-to-histfile")
                     .help("Also append new history to $HISTFILE/$MCFLY_HISTFILE (e.q., .bash_history)"))
-                .arg(Arg::with_name("zsh_extended_history")
-                    .long("zsh-extended-history")
-                    .help("If appending, use zsh's EXTENDED_HISTORY format"))
                 .arg(Arg::with_name("when")
                     .short("w")
                     .long("when")
@@ -314,6 +311,9 @@ impl Settings {
             Some("zsh") => HistoryFormat::Zsh {
                 extended_history: false,
             },
+            Some("zsh-extended") => HistoryFormat::Zsh {
+                extended_history: true
+            },
             Some("fish") => HistoryFormat::Fish,
             Some(format) => panic!("McFly error: unknown history format '{}'", format),
         };
@@ -334,12 +334,6 @@ impl Settings {
                 );
 
                 settings.append_to_histfile = add_matches.is_present("append_to_histfile");
-                if add_matches.is_present("zsh_extended_history") {
-                    match settings.history_format {
-                        HistoryFormat::Zsh { .. } => settings.history_format = HistoryFormat::Zsh { extended_history: true },
-                        HistoryFormat::Bash | HistoryFormat::Fish => panic!("McFly error: cannot specify zsh extended history with non-zsh history format"),
-                    }
-                }
 
                 if add_matches.value_of("exit").is_some() {
                     settings.exit_code =


### PR DESCRIPTION
Fixes #220

Backwards incompatible change: `--zsh_extended_history` argument to `mcfly add` is removed as history mode for Zsh is now properly detected.