### PR TITLE
Iss140 - disable menu interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,19 @@ fish:
 set -gx MCFLY_INTERFACE_VIEW BOTTOM
 ```
 
+### Disable menu interface
+To disable the menu interface, set the environment variable `MCFLY_DISABLE_MENU`.
+
+bash / zsh:
+```bash
+export MCFLY_DISABLE_MENU=TRUE
+```
+
+fish:
+```bash
+set -gx MCFLY_DISABLE_MENU TRUE
+```
+
 ### Results sorting
 To change the sorting of results shown, set `MCFLY_RESULTS_SORT` (default: RANK).
 Possible values `RANK` and `LAST_RUN`

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -133,21 +133,23 @@ impl<'a> Interface<'a> {
     }
 
     fn menubar<W: Write>(&self, screen: &mut W) {
-        let (width, _height): (u16, u16) = terminal_size().unwrap();
-        write!(
-            screen,
-            "{hide}{cursor}{clear}{fg}{bg}{text:width$}{reset_bg}",
-            hide = cursor::Hide,
-            fg = color::Fg(color::LightWhite),
-            bg = self.menu_mode.bg(),
-            cursor = cursor::Goto(1, self.info_line_index()),
-            clear = clear::CurrentLine,
-            text = self.menu_mode.text(self),
-            reset_bg = color::Bg(color::Reset),
-            width = width as usize
-        )
-        .unwrap();
-        screen.flush().unwrap();
+        if !self.settings.disable_menu {
+            let (width, _height): (u16, u16) = terminal_size().unwrap();
+            write!(
+                screen,
+                "{hide}{cursor}{clear}{fg}{bg}{text:width$}{reset_bg}",
+                hide = cursor::Hide,
+                fg = color::Fg(color::LightWhite),
+                bg = self.menu_mode.bg(),
+                cursor = cursor::Goto(1, self.info_line_index()),
+                clear = clear::CurrentLine,
+                text = self.menu_mode.text(self),
+                reset_bg = color::Bg(color::Reset),
+                width = width as usize
+            )
+            .unwrap();
+            screen.flush().unwrap();   
+        }
     }
 
     fn prompt<W: Write>(&self, screen: &mut W) {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -148,7 +148,7 @@ impl<'a> Interface<'a> {
                 width = width as usize
             )
             .unwrap();
-            screen.flush().unwrap();   
+            screen.flush().unwrap();
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,7 @@ pub struct Settings {
     pub delete_without_confirm: bool,
     pub interface_view: InterfaceView,
     pub result_sort: ResultSort,
+    pub disable_menu: bool,
 }
 
 impl Default for Settings {
@@ -114,6 +115,7 @@ impl Default for Settings {
             delete_without_confirm: false,
             interface_view: InterfaceView::Top,
             result_sort: ResultSort::Rank,
+            disable_menu: false,
         }
     }
 }
@@ -480,6 +482,12 @@ impl Settings {
             Some(_val) => true,
             None => false,
         };
+
+        settings.disable_menu = match env::var_os("MCFLY_DISABLE_MENU") {
+            Some(_val) => true,
+            None => false,
+        };
+
         settings.key_scheme = match env::var("MCFLY_KEY_SCHEME").as_ref().map(String::as_ref) {
             Ok("vim") => KeyScheme::Vim,
             _ => KeyScheme::Emacs,


### PR DESCRIPTION
Using an env variable 'MCFLY_DISABLE_MENU', the user can now choose to disable the menu interface.

I also updated the README with instructions on how to disable the menu interface

Closes #140 