### PR TITLE
Don't prepend extra copies to prompt command

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -60,7 +60,8 @@ function mcfly_prompt_command {
 if [ -z "$PROMPT_COMMAND" ]
 then
   PROMPT_COMMAND="mcfly_prompt_command"
-else
+elif [[ ! "$PROMPT_COMMAND" =~ "mcfly_prompt_command" ]]
+then
   PROMPT_COMMAND="mcfly_prompt_command;${PROMPT_COMMAND#;}"
 fi
 


### PR DESCRIPTION
When starting subshells, extra copies of mcfly_prompt_command can get preprended. 
Instead, check first and only prepend if not found.