### PR TITLE
Intermediate `source <(mcfly init *sh)` during initialisation. Fixes #254, #219, #239

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -2,14 +2,27 @@ use super::settings::InitMode;
 
 pub struct Init {}
 
+// Intermediating a `source <(...)` step is important so that the actual init
+// scripts don't have too much power in `.bashrc` or `.zshrc` when `eval()`'d. For
+// instance eval'ing `return 0` returns from the _entire_ .bashrc/.zshrc script,
+// not just the mcfly init script.
+//
+// Perhaps just asking users to directly `source <(mcfly init bash --print_full_init)`
+// is better, but we now also need to be backward compatible for those that already
+// have `eval "$(mcfly init bash)"` in their config.
+//
+// See: https://github.com/cantino/mcfly/issues/254
+const BASH_SOURCE_STANZA: &str = "source <(mcfly init bash --print_full_init)";
+const ZSH_SOURCE_STANZA: &str = "source <(mcfly init zsh --print_full_init)";
+
 impl Init {
-    pub fn new(init_mode: &InitMode) -> Self {
+    pub fn new(init_mode: &InitMode, is_print_full_init: bool) -> Self {
         match init_mode {
             InitMode::Bash => {
-                Init::init_bash();
+                Init::init_bash(is_print_full_init);
             }
             InitMode::Zsh => {
-                Init::init_zsh();
+                Init::init_zsh(is_print_full_init);
             }
             InitMode::Fish => {
                 Init::init_fish();
@@ -17,13 +30,21 @@ impl Init {
         }
         Self {}
     }
-    pub fn init_bash() {
-        let script = include_str!("../mcfly.bash");
-        print!("{}", script);
+    pub fn init_bash(is_print_full_init: bool) {
+        if is_print_full_init {
+            let script = include_str!("../mcfly.bash");
+            print!("{}", script);
+        } else {
+            print!("{}", BASH_SOURCE_STANZA);
+        }
     }
-    pub fn init_zsh() {
-        let script = include_str!("../mcfly.zsh");
-        print!("{}", script);
+    pub fn init_zsh(is_print_full_init: bool) {
+        if is_print_full_init {
+            let script = include_str!("../mcfly.zsh");
+            print!("{}", script);
+        } else {
+            print!("{}", ZSH_SOURCE_STANZA);
+        }
     }
     pub fn init_fish() {
         let script = include_str!("../mcfly.fish");

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn handle_move(settings: &Settings) {
 }
 
 fn handle_init(settings: &Settings) {
-    Init::new(&settings.init_mode);
+    Init::new(&settings.init_mode, settings.print_full_init);
 }
 
 fn main() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,6 +87,7 @@ pub struct Settings {
     pub interface_view: InterfaceView,
     pub result_sort: ResultSort,
     pub disable_menu: bool,
+    pub print_full_init: bool,
 }
 
 impl Default for Settings {
@@ -116,6 +117,7 @@ impl Default for Settings {
             interface_view: InterfaceView::Top,
             result_sort: ResultSort::Rank,
             disable_menu: false,
+            print_full_init: false,
         }
     }
 }
@@ -243,6 +245,9 @@ impl Settings {
                     .help("Shell to init — one of bash, zsh, or fish")
                     .possible_values(&["bash", "zsh", "fish"])
                     .required(true))
+                .arg(Arg::with_name("print_full_init")
+                    .long("print_full_init")
+                    .help("Output full init code as opposed to just `source <(...)`"))
             )
             .get_matches();
 
@@ -460,6 +465,7 @@ impl Settings {
 
             ("init", Some(init_matches)) => {
                 settings.mode = Mode::Init;
+                settings.print_full_init = init_matches.is_present("print_full_init");
                 match init_matches.value_of("shell").unwrap() {
                     "bash" => {
                         settings.init_mode = InitMode::Bash;


### PR DESCRIPTION
As requested in #254.

I don't know anything about Fish, but I assume this issue didn't affect it?