### PR TITLE
Revert "Intermediate `source <(mcfly init *sh)` during initialisation. Fixes #254, #219, #239"

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -2,27 +2,14 @@ use super::settings::InitMode;
 
 pub struct Init {}
 
-// Intermediating a `source <(...)` step is important so that the actual init
-// scripts don't have too much power in `.bashrc` or `.zshrc` when `eval()`'d. For
-// instance eval'ing `return 0` returns from the _entire_ .bashrc/.zshrc script,
-// not just the mcfly init script.
-//
-// Perhaps just asking users to directly `source <(mcfly init bash --print_full_init)`
-// is better, but we now also need to be backward compatible for those that already
-// have `eval "$(mcfly init bash)"` in their config.
-//
-// See: https://github.com/cantino/mcfly/issues/254
-const BASH_SOURCE_STANZA: &str = "source <(mcfly init bash --print_full_init)";
-const ZSH_SOURCE_STANZA: &str = "source <(mcfly init zsh --print_full_init)";
-
 impl Init {
-    pub fn new(init_mode: &InitMode, is_print_full_init: bool) -> Self {
+    pub fn new(init_mode: &InitMode) -> Self {
         match init_mode {
             InitMode::Bash => {
-                Init::init_bash(is_print_full_init);
+                Init::init_bash();
             }
             InitMode::Zsh => {
-                Init::init_zsh(is_print_full_init);
+                Init::init_zsh();
             }
             InitMode::Fish => {
                 Init::init_fish();
@@ -30,21 +17,13 @@ impl Init {
         }
         Self {}
     }
-    pub fn init_bash(is_print_full_init: bool) {
-        if is_print_full_init {
-            let script = include_str!("../mcfly.bash");
-            print!("{}", script);
-        } else {
-            print!("{}", BASH_SOURCE_STANZA);
-        }
+    pub fn init_bash() {
+        let script = include_str!("../mcfly.bash");
+        print!("{}", script);
     }
-    pub fn init_zsh(is_print_full_init: bool) {
-        if is_print_full_init {
-            let script = include_str!("../mcfly.zsh");
-            print!("{}", script);
-        } else {
-            print!("{}", ZSH_SOURCE_STANZA);
-        }
+    pub fn init_zsh() {
+        let script = include_str!("../mcfly.zsh");
+        print!("{}", script);
     }
     pub fn init_fish() {
         let script = include_str!("../mcfly.fish");

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn handle_move(settings: &Settings) {
 }
 
 fn handle_init(settings: &Settings) {
-    Init::new(&settings.init_mode, settings.print_full_init);
+    Init::new(&settings.init_mode);
 }
 
 fn main() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,7 +87,6 @@ pub struct Settings {
     pub interface_view: InterfaceView,
     pub result_sort: ResultSort,
     pub disable_menu: bool,
-    pub print_full_init: bool,
 }
 
 impl Default for Settings {
@@ -117,7 +116,6 @@ impl Default for Settings {
             interface_view: InterfaceView::Top,
             result_sort: ResultSort::Rank,
             disable_menu: false,
-            print_full_init: false,
         }
     }
 }
@@ -245,9 +243,6 @@ impl Settings {
                     .help("Shell to init — one of bash, zsh, or fish")
                     .possible_values(&["bash", "zsh", "fish"])
                     .required(true))
-                .arg(Arg::with_name("print_full_init")
-                    .long("print_full_init")
-                    .help("Output full init code as opposed to just `source <(...)`"))
             )
             .get_matches();
 
@@ -465,7 +460,6 @@ impl Settings {
 
             ("init", Some(init_matches)) => {
                 settings.mode = Mode::Init;
-                settings.print_full_init = init_matches.is_present("print_full_init");
                 match init_matches.value_of("shell").unwrap() {
                     "bash" => {
                         settings.init_mode = InitMode::Bash;


### PR DESCRIPTION
Reverts cantino/mcfly#255