### PR TITLE
re-enable aarch64-apple-darwin tests

### DIFF
--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           command: test
           args: --target ${{ matrix.target }}
-          use-cross: false
+          use-cross: true
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -32,9 +32,7 @@ jobs:
         channel: [stable, beta, nightly]
         target:
           - x86_64-apple-darwin
-          ### Disable running tests on M1 target, not currently working
-          ### https://github.com/rust-lang/rust/issues/73908
-          # - aarch64-apple-darwin
+          - aarch64-apple-darwin
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Testing re-enabling these. It has been over a year since https://github.com/cantino/mcfly/commit/6e158015f1c9a535907b0454c2b190366b3866ed disabled them, so maybe try again ?