### PR TITLE
Fix vim append command

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -595,7 +595,15 @@ impl<'a> Interface<'a> {
                 Key::Char('w') => self.input.move_cursor(Move::ForwardWord),
                 Key::Char('0') | Key::Char('^') => self.input.move_cursor(Move::BOL),
                 Key::Char('$') => self.input.move_cursor(Move::EOL),
-                Key::Char('i') | Key::Char('a') => self.in_vim_insert_mode = true,
+                Key::Char('i') => self.in_vim_insert_mode = true,
+                Key::Char('a') => {
+                    self.input.move_cursor(Move::Forward);
+                    self.in_vim_insert_mode = true;
+                }
+                Key::Char('A') => {
+                    self.input.move_cursor(Move::EOL);
+                    self.in_vim_insert_mode = true;
+                }
                 Key::Backspace => {
                     self.input.delete(Move::Backward);
                     self.refresh_matches();

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -596,6 +596,10 @@ impl<'a> Interface<'a> {
                 Key::Char('0') | Key::Char('^') => self.input.move_cursor(Move::BOL),
                 Key::Char('$') => self.input.move_cursor(Move::EOL),
                 Key::Char('i') => self.in_vim_insert_mode = true,
+                Key::Char('I') => {
+                    self.input.move_cursor(Move::BOL);
+                    self.in_vim_insert_mode = true;
+                }
                 Key::Char('a') => {
                     self.input.move_cursor(Move::Forward);
                     self.in_vim_insert_mode = true;


### PR DESCRIPTION
This is a slight vim mode improvement to make insert and append commands work like in vim.

i => Inserts at the current position
I => inserts at the beginning of the line.
a => inserts at one position to the right.
A => inserts at the end of the line.