### PR TITLE
implemented feature to switch result sort by key binding

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -519,7 +519,10 @@ impl<'a> Interface<'a> {
                 self.input.insert(c);
                 self.refresh_matches();
             }
-            Key::F(1) => self.switch_result_sort(),
+            Key::F(1) => {
+                self.switch_result_sort();
+                self.refresh_matches();
+            },
             Key::F(2) => {
                 if !self.matches.is_empty() {
                     if self.settings.delete_without_confirm {
@@ -576,7 +579,10 @@ impl<'a> Interface<'a> {
                     self.input.insert(c);
                     self.refresh_matches();
                 }
-                Key::F(1) => self.switch_result_sort(),
+                Key::F(1) => {
+                    self.switch_result_sort();
+                    self.refresh_matches();
+                },
                 Key::F(2) => {
                     if !self.matches.is_empty() {
                         if self.settings.delete_without_confirm {
@@ -645,7 +651,10 @@ impl<'a> Interface<'a> {
                 Key::Char(_c) => {
 
                 }
-                Key::F(1) => self.switch_result_sort(),
+                Key::F(1) => {
+                    self.switch_result_sort();
+                    self.refresh_matches();
+                },
                 Key::F(2) => {
                     if !self.matches.is_empty() {
                         if self.settings.delete_without_confirm {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -522,7 +522,7 @@ impl<'a> Interface<'a> {
             Key::F(1) => {
                 self.switch_result_sort();
                 self.refresh_matches();
-            },
+            }
             Key::F(2) => {
                 if !self.matches.is_empty() {
                     if self.settings.delete_without_confirm {
@@ -582,7 +582,7 @@ impl<'a> Interface<'a> {
                 Key::F(1) => {
                     self.switch_result_sort();
                     self.refresh_matches();
-                },
+                }
                 Key::F(2) => {
                     if !self.matches.is_empty() {
                         if self.settings.delete_without_confirm {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -4,8 +4,8 @@ use crate::history::History;
 use crate::fixed_length_grapheme_string::FixedLengthGraphemeString;
 use crate::history::Command;
 use crate::history_cleaner;
-use crate::settings::Settings;
 use crate::settings::{InterfaceView, KeyScheme};
+use crate::settings::{ResultSort, Settings};
 use chrono::{Duration, TimeZone, Utc};
 use humantime::format_duration;
 use std::io::{stdin, stdout, Write};
@@ -27,6 +27,7 @@ pub struct Interface<'a> {
     delete_requests: Vec<String>,
     menu_mode: MenuMode,
     in_vim_insert_mode: bool,
+    result_sort: ResultSort,
 }
 
 pub struct SelectionResult {
@@ -50,20 +51,33 @@ pub enum MenuMode {
 }
 
 impl MenuMode {
-    fn text(&self, interface: &Interface) -> &str {
+    fn text(&self, interface: &Interface) -> String {
+        let mut menu_text = String::from("McFly");
         match *self {
             MenuMode::Normal => match interface.settings.key_scheme {
-                KeyScheme::Emacs => "McFly | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete",
+                KeyScheme::Emacs => menu_text.push_str(" | ESC - Exit | "),
                 KeyScheme::Vim => {
                     if interface.in_vim_insert_mode {
-                        "McFly (Ins) | ESC - Cmd  | ⏎ - Run | TAB - Edit | F2 - Delete"
+                        menu_text.push_str(" (Ins) | ESC - Cmd | ");
                     } else {
-                        "McFly (Cmd) | ESC - Exit | ⏎ - Run | TAB - Edit | F2 - Delete"
+                        menu_text.push_str(" (Cmd) | ESC - Exit | ");
                     }
                 }
             },
-            MenuMode::ConfirmDelete => "Delete selected command from the history? (Y/N)",
+            MenuMode::ConfirmDelete => {
+                return String::from("Delete selected command from the history? (Y/N)")
+            }
         }
+
+        menu_text.push_str("⏎ - Run | TAB - Edit | ");
+
+        match interface.result_sort {
+            ResultSort::Rank => menu_text.push_str("F1 - Sort (Time) | "),
+            ResultSort::LastRun => menu_text.push_str("F1 - Sort (Rank) | "),
+        }
+
+        menu_text.push_str("F2 - Delete");
+        menu_text
     }
 
     fn bg(&self) -> String {
@@ -91,6 +105,7 @@ impl<'a> Interface<'a> {
             delete_requests: Vec::new(),
             menu_mode: MenuMode::Normal,
             in_vim_insert_mode: true,
+            result_sort: settings.result_sort.to_owned(),
         }
     }
 
@@ -381,8 +396,15 @@ impl<'a> Interface<'a> {
             &self.input.command,
             self.settings.results as i16,
             self.settings.fuzzy,
-            &self.settings.result_sort,
+            &self.result_sort,
         );
+    }
+
+    fn switch_result_sort(&mut self) {
+        match self.result_sort {
+            ResultSort::Rank => self.result_sort = ResultSort::LastRun,
+            ResultSort::LastRun => self.result_sort = ResultSort::Rank,
+        }
     }
 
     fn select(&mut self) {
@@ -497,6 +519,7 @@ impl<'a> Interface<'a> {
                 self.input.insert(c);
                 self.refresh_matches();
             }
+            Key::F(1) => self.switch_result_sort(),
             Key::F(2) => {
                 if !self.matches.is_empty() {
                     if self.settings.delete_without_confirm {
@@ -553,6 +576,7 @@ impl<'a> Interface<'a> {
                     self.input.insert(c);
                     self.refresh_matches();
                 }
+                Key::F(1) => self.switch_result_sort(),
                 Key::F(2) => {
                     if !self.matches.is_empty() {
                         if self.settings.delete_without_confirm {
@@ -621,6 +645,7 @@ impl<'a> Interface<'a> {
                 Key::Char(_c) => {
 
                 }
+                Key::F(1) => self.switch_result_sort(),
                 Key::F(2) => {
                     if !self.matches.is_empty() {
                         if self.settings.delete_without_confirm {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -37,7 +37,7 @@ pub enum InterfaceView {
     Bottom,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ResultSort {
     Rank,
     LastRun,


### PR DESCRIPTION
Closes #238 
- Added result_sort as an attribute to Interface so we can mutate it. Similar to interface.input
- When creating new instance of Interface, result_sort is set to settings.result_sort.to_owned()
- Added a new function switch_result_sort, which switches between the two result sorts. It is called by pressing F1, regardless of the key scheme.
- Added the clone trait to ResultSort Enum
- Passed in the new interface.result_sort into interface.history.find_matches 
- Finally, I rewrote the MenuMode.text function. I rewrote it because it would have become a mess trying to add an additional match statement to each of the existing match statements. For clarification, if I did not rewrite it, It would look like the following:

```rust
impl MenuMode {
    fn text(&self, interface: &Interface) -> &str {
        match *self {
            MenuMode::Normal => match interface.settings.key_scheme {
                KeyScheme::Emacs => match interface.result_sort {
                    ResultSort::Rank => "McFly | ESC - Exit | ⏎ - Run | TAB - Edit | F1 - Sort (Time) | F2 - Delete",
                    ResultSort::LastRun => "McFly | ESC - Exit | ⏎ - Run | TAB - Edit | F1 - Sort (Rank) | F2 - Delete",
                }
                KeyScheme::Vim => {
                    if interface.in_vim_insert_mode {
                        match interface.result_sort {
                            ResultSort::Rank => "McFly (Ins) | ESC - Cmd | ⏎ - Run | TAB - Edit | F1 - Sort (Time) | F2 - Delete",
                            ResultSort::LastRun => "McFly (Ins) | ESC - Cmd | ⏎ - Run | TAB - Edit | F1 - Sort (Rank) | F2 - Delete",
                        }
                    } else {
                        match interface.result_sort {
                            ResultSort::Rank => "McFly (Cmd) | ESC - Exit | ⏎ - Run | TAB - Edit | F1 - Sort (Time) | F2 - Delete",
                            ResultSort::LastRun => "McFly (Cmd) | ESC - Exit| ⏎ - Run | TAB - Edit | F1 - Sort (Rank) | F2 - Delete",
                        }
                    }
                }
            },
            MenuMode::ConfirmDelete => "Delete selected command from the history? (Y/N)",
        }
    }
```

Also, I think by rewriting this function, reduces the number of places we have to add new key bindings. Above, we would have to change all 6 of the different strings. While with the new rewrite, the programmer has to figure out where to append the new keybinding.

Let me know your thoughts @cantino 