### PR TITLE
Fix the handling of open-quote strings in fish

### DIFF
--- a/mcfly.fish
+++ b/mcfly.fish
@@ -44,7 +44,7 @@ if test "$__MCFLY_LOADED" != "loaded"
   if status is-interactive
     function __mcfly-history-widget -d "Search command history with McFly"
       set -l mcfly_output (mktemp -t mcfly.output.XXXXXXXX)
-      eval $__MCFLY_CMD search -o '$mcfly_output' -- (commandline)
+      eval $__MCFLY_CMD search -o '$mcfly_output' -- (commandline | string escape)
 
       # Interpret commandline/run requests from McFly
       set -l mode; set -l commandline


### PR DESCRIPTION
In fish, with McFly initiated, hitting Control-R when the existing
command line contains an unmatched quote currently triggers a fish
error, e.g.:

```
❯ echo "Hi- (line 1): Unexpected end of string, quotes are not balanced
/opt/homebrew/bin/mcfly --mcfly_history /dev/null --history_format fish search -o $mcfly_output -- echo "Hi
                                                                                                        ^
```

Fortunately, the solution is simple: use fish's own `string escape` to
escape the output of `commandline` before passing it to `mcfly` as an
argument.