### PR TITLE
implemented fix to sort by time

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -396,7 +396,7 @@ impl History {
             }));
         }
 
-        if fuzzy > 0 {
+        if fuzzy > 0 && result_sort != &ResultSort::LastRun {
             names = names
                 .into_iter()
                 .sorted_by(|a, b| {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -37,7 +37,7 @@ pub enum InterfaceView {
     Bottom,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResultSort {
     Rank,
     LastRun,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -37,7 +37,7 @@ pub enum InterfaceView {
     Bottom,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ResultSort {
     Rank,
     LastRun,


### PR DESCRIPTION
Added a conditional check to see if the user is sorting by time. If they are, we skip fuzzy matches when sorting.

Closes #282 