### PR TITLE
Fix #288 - enable compatibility with `mktemp` from `uutils/coreutils`

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -35,7 +35,7 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
     # Populate McFly's temporary, per-session history file from recent commands in the shell's primary HISTFILE.
     if [[ ! -f "${MCFLY_HISTORY}" ]]; then
-      MCFLY_HISTORY=$(mktemp -t mcfly.XXXXXXXX)
+      MCFLY_HISTORY=$(mktemp ${TMPDIR:/tmp}/mcfly.XXXXXXXX)
       export MCFLY_HISTORY
       command tail -n100 "${HISTFILE}" >| "${MCFLY_HISTORY}"
     fi

--- a/mcfly.fish
+++ b/mcfly.fish
@@ -43,7 +43,7 @@ if test "$__MCFLY_LOADED" != "loaded"
   # If this is an interactive shell, set up key binding functions.
   if status is-interactive
     function __mcfly-history-widget -d "Search command history with McFly"
-      set -l mcfly_output (mktemp -t mcfly.output.XXXXXXXX)
+      set -l mcfly_output (mktemp ${TMPDIR:/tmp}/mcfly.output.XXXXXXXX)
       eval $__MCFLY_CMD search -o '$mcfly_output' -- (commandline | string escape)
 
       # Interpret commandline/run requests from McFly

--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -27,7 +27,7 @@ if [[ -o interactive ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
   # McFly's temporary, per-session history file.
   if [[ ! -f "${MCFLY_HISTORY}" ]]; then
-    export MCFLY_HISTORY=$(command mktemp -t mcfly.XXXXXXXX)
+    export MCFLY_HISTORY=$(command mktemp ${TMPDIR:/tmp}/mcfly.XXXXXXXX)
   fi
 
   # Check if we need to use extended history
@@ -43,7 +43,7 @@ if [[ -o interactive ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
     # Populate McFly's temporary, per-session history file from recent commands in the shell's primary HISTFILE.
     if [[ ! -f "${MCFLY_HISTORY}" ]]; then
-      export MCFLY_HISTORY=$(command mktemp -t mcfly.XXXXXXXX)
+      export MCFLY_HISTORY=$(command mktemp ${TMPDIR:/tmp}/mcfly.XXXXXXXX)
       command tail -n100 "${HISTFILE}" >| ${MCFLY_HISTORY}
     fi
 
@@ -70,7 +70,7 @@ if [[ -o interactive ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
       () {
         echoti rmkx
         exec </dev/tty
-        local mcfly_output=$(mktemp -t mcfly.output.XXXXXXXX)
+        local mcfly_output=$(mktemp ${TMPDIR:/tmp}/mcfly.output.XXXXXXXX)
         $MCFLY_PATH --history_format $MCFLY_HISTORY_FORMAT search -o "${mcfly_output}" "${LBUFFER}"
         echoti smkx
 


### PR DESCRIPTION
Per #288, use:

`mktemp ${TMPDIR:/tmp}/mcfly.XXXXXXXX`

instead of:

`mktemp -t mcfly.XXXXXXXX`

This enables compatibility with `mktemp` from [uutils/coreutils](https://github.com/uutils/coreutils).