### PR TITLE
Add support for fzf as a frontend UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,25 @@ fish:
 ```bash
 set -gx MCFLY_RESULTS_SORT LAST_RUN
 ```
+### Integration with fzf
+To use `fzf` as the search UI for `Ctrl+R` in terminal, set the environment variable
+`MCFLY_FZF` prior to loading mcfly via `mcfly init`. `fzf` must be installed separately 
+([instructions](https://github.com/junegunn/fzf#installation)).
+
+bash / zsh:
+```bash
+export MCFLY_FZF=TRUE
+```
+
+fish:
+```bash
+set -gx MCFLY_FZF TRUE
+```
+
+Tips:
+- The `fzf` interface does not support deleting history entries. Manually run `mcfly search` to access the standard UI.
+- Modify the environment variable `FZF_CTRL_R_OPTS` to pass custom flags for the
+  `fzf` interface
 
 ### Database Location
 

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -63,22 +63,50 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
   # If this is an interactive shell, take ownership of ctrl-r.
   if [[ $- =~ .*i.* ]]; then
-    if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
-      # shellcheck disable=SC2016
-      bind -x '"\C-r": "echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY ; READLINE_LINE= ; mcfly search"'
-    else
-      # The logic here is:
-      #   1. Jump to the beginning of the edit buffer, add 'mcfly: ', and comment out the current line. We comment out the line
-      #      to ensure that all possible special characters, including backticks, are ignored. This commented out line will
-      #      end up as the most recent entry in the $MCFLY_HISTORY file.
-      #   2. Type "mcfly search" and then run the command. McFly will pull the last line from the $MCFLY_HISTORY file,
-      #      which should be the commented-out search from step #1. It will then remove that line from the history file and
-      #      render the search UI pre-filled with it.
-      if set -o | grep "vi " | grep -q on; then
-        bind "'\C-r': '\e0i#mcfly: \e\C-m mcfly search\C-m'"
+
+    # Function to perform ctrl-r binding for fzf. Adapted from junegunn/fzf shell/key-bindings.bash
+    __mcfly_fzf_history__() {
+      local output opts script header
+      opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS 
+          --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
+          --header='F1 Sort Rank | F2 Sort Time | Ctrl-R Toggle Sort'
+          --bind=ctrl-r:toggle-sort 
+          --bind='f1:reload(mcfly fzf -0 --sort RANK)' 
+          --bind='f2:reload(mcfly fzf -0 --sort LAST_RUN)' 
+          $FZF_CTRL_R_OPTS +m"
+      output=$(
+        mcfly fzf -0 |
+          FZF_DEFAULT_OPTS="$opts" fzf --query "$READLINE_LINE"
+      ) || return
+      READLINE_LINE=${output#*$'\t'}
+      if [[ -z "$READLINE_POINT" ]]; then
+        echo "$READLINE_LINE"
       else
-        bind "'\C-r': '\C-amcfly: \e# mcfly search\C-m'"
+        READLINE_POINT=0x7fffffff
       fi
+    }
+
+    if [ -z "$MCFLY_FZF" ]; then
+      # Perform standard ctrl-r bindings
+      if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
+        # shellcheck disable=SC2016
+        bind -x '"\C-r": "echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY ; READLINE_LINE= ; mcfly search"'
+      else
+        # The logic here is:
+        #   1. Jump to the beginning of the edit buffer, add 'mcfly: ', and comment out the current line. We comment out the line
+        #      to ensure that all possible special characters, including backticks, are ignored. This commented out line will
+        #      end up as the most recent entry in the $MCFLY_HISTORY file.
+        #   2. Type "mcfly search" and then run the command. McFly will pull the last line from the $MCFLY_HISTORY file,
+        #      which should be the commented-out search from step #1. It will then remove that line from the history file and
+        #      render the search UI pre-filled with it.
+        if set -o | grep "vi " | grep -q on; then
+          bind "'\C-r': '\e0i#mcfly: \e\C-m mcfly search\C-m'"
+        else
+          bind "'\C-r': '\C-amcfly: \e# mcfly search\C-m'"
+        fi
+      fi
+    else 
+      bind -x '"\C-r": __mcfly_fzf_history__'
     fi
   fi
 

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -71,14 +71,15 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
           --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
           --header='F1 Sort Rank | F2 Sort Time | Ctrl-R Toggle Sort'
           --bind=ctrl-r:toggle-sort 
-          --bind='f1:reload(mcfly fzf -0 --sort RANK)' 
-          --bind='f2:reload(mcfly fzf -0 --sort LAST_RUN)' 
+          --bind='f1:reload(mcfly fzf show -0 --sort RANK)' 
+          --bind='f2:reload(mcfly fzf show -0 --sort LAST_RUN)' 
           $FZF_CTRL_R_OPTS +m"
       output=$(
-        mcfly fzf -0 |
+        mcfly fzf show -0 |
           FZF_DEFAULT_OPTS="$opts" fzf --query "$READLINE_LINE"
       ) || return
       READLINE_LINE=${output#*$'\t'}
+      mcfly fzf select -- "$READLINE_LINE"
       if [[ -z "$READLINE_POINT" ]]; then
         echo "$READLINE_LINE"
       else

--- a/mcfly.fish
+++ b/mcfly.fish
@@ -77,13 +77,14 @@ if test "$__MCFLY_LOADED" != "loaded"
             --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
             --header='F1 Sort Rank | F2 Sort Time | Ctrl-R Toggle Sort'
             --bind=ctrl-r:toggle-sort 
-            --bind='f1:reload(mcfly fzf -0 --sort RANK)' 
-            --bind='f2:reload(mcfly fzf -0 --sort LAST_RUN)' 
+            --bind='f1:reload(mcfly fzf show -0 --sort RANK)' 
+            --bind='f2:reload(mcfly fzf show -0 --sort LAST_RUN)' 
             $FZF_CTRL_R_OPTS +m"
 
-          eval $__MCFLY_CMD fzf -0 | eval fzf -q '(commandline)' | 
+          eval $__MCFLY_CMD fzf show -0 | eval fzf -q '(commandline)' | 
           string replace -r "[^\t]*\t" "" | read -l result
           and commandline -- $result
+          and eval $__MCFLY_CMD fzf select -- "$result"
         end
         commandline -f repaint
       end

--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -102,18 +102,21 @@ if [[ -o interactive ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
           --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
           --header='F1 Sort Rank | F2 Sort Time | Ctrl-R Toggle Sort'
           --bind=ctrl-r:toggle-sort 
-          --bind='f1:reload(mcfly fzf -0 --sort RANK)' 
-          --bind='f2:reload(mcfly fzf -0 --sort LAST_RUN)' 
+          --bind='f1:reload(mcfly fzf show -0 --sort RANK)' 
+          --bind='f2:reload(mcfly fzf show -0 --sort LAST_RUN)' 
           $FZF_CTRL_R_OPTS +m"
 
         selected=$(
-          mcfly fzf -0 | FZF_DEFAULT_OPTS="$opts" fzf --query="$LBUFFER"
+          mcfly fzf show -0 | FZF_DEFAULT_OPTS="$opts" fzf --query="$LBUFFER"
         )
 
         local ret=$?
         if [ -n "$selected" ]; then
           RBUFFER=""
           LBUFFER="${selected#*$'\t'}"
+          if [ $ret -eq 0 ]; then
+            mcfly fzf select -- "$LBUFFER"
+          fi
         fi
         zle reset-prompt
         #maybe zle redisplay?

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -1,0 +1,52 @@
+use std::io::Write;
+
+use crate::settings::{ResultSort, self};
+use crate::history::History;
+
+pub fn run(history: &History, sort_by: &ResultSort, zero_separated: bool) {
+    let order_by_column: &str = match sort_by {
+        settings::ResultSort::LastRun => "last_run DESC",
+        _ => "rank DESC",
+    };
+
+    let query: &str = &format!(
+        "{} {} {}",
+        "SELECT cmd, last_run 
+        FROM contextual_commands",
+        "ORDER BY",
+        order_by_column
+    )[..];
+
+    let mut statement = history
+        .connection
+        .prepare(query)
+        .unwrap_or_else(|err| panic!("McFly error: Prepare to work ({})", err));
+    let mut rows = statement.query([]).unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
+
+    let mut stdout = std::io::stdout();
+
+    while let Ok(Some(row)) = rows.next() {
+        let cmd: String = row.get(0).unwrap_or_else(|err| {
+            panic!(
+                "Mcfly error: unable to read database result column 'cmd': {}",
+                err
+            )
+        });
+        let last_run: i64 = row.get(1).unwrap_or_else(|err| {
+            panic!(
+                "Mcfly error: unable to read database result column 'last_run': {}",
+                err
+            )
+        });
+        
+        let duration = crate::interface::format_time_since(last_run);
+        let res = if zero_separated {
+            stdout.write_fmt(format_args!("{}\t{}\0", duration, cmd))
+        } else {
+            stdout.write_fmt(format_args!("{}\t{}\n", duration, cmd))
+        };
+        if let Err(_) = res {
+            break
+        }
+    }
+}

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use crate::settings::{ResultSort, self};
 use crate::history::History;
+use crate::settings::{self, ResultSort};
 
 pub fn run(history: &History, sort_by: &ResultSort, zero_separated: bool) {
     let order_by_column: &str = match sort_by {
@@ -21,7 +21,9 @@ pub fn run(history: &History, sort_by: &ResultSort, zero_separated: bool) {
         .connection
         .prepare(query)
         .unwrap_or_else(|err| panic!("McFly error: Prepare to work ({})", err));
-    let mut rows = statement.query([]).unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
+    let mut rows = statement
+        .query([])
+        .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
 
     let mut stdout = std::io::stdout();
 
@@ -38,15 +40,15 @@ pub fn run(history: &History, sort_by: &ResultSort, zero_separated: bool) {
                 err
             )
         });
-        
+
         let duration = crate::interface::format_time_since(last_run);
         let res = if zero_separated {
             stdout.write_fmt(format_args!("{}\t{}\0", duration, cmd))
         } else {
             stdout.write_fmt(format_args!("{}\t{}\n", duration, cmd))
         };
-        if let Err(_) = res {
-            break
+        if res.is_err() {
+            break;
         }
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,7 @@
 use crate::command_input::{CommandInput, Move};
-use crate::history::History;
 use crate::fixed_length_grapheme_string::FixedLengthGraphemeString;
 use crate::history::Command;
+use crate::history::History;
 use crate::history_cleaner;
 use crate::settings::{InterfaceView, KeyScheme};
 use crate::settings::{ResultSort, Settings};

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,13 +1,11 @@
 use crate::command_input::{CommandInput, Move};
 use crate::history::History;
-
 use crate::fixed_length_grapheme_string::FixedLengthGraphemeString;
 use crate::history::Command;
 use crate::history_cleaner;
 use crate::settings::{InterfaceView, KeyScheme};
 use crate::settings::{ResultSort, Settings};
 use chrono::{Duration, TimeZone, Utc};
-use humantime::format_duration;
 use std::io::{stdin, stdout, Write};
 use termion::color;
 use termion::event::Key;
@@ -280,35 +278,7 @@ impl<'a> Interface<'a> {
                 )
                 .unwrap();
 
-                let duration = &format_duration(
-                    Duration::minutes(
-                        Utc::now()
-                            .signed_duration_since(
-                                Utc.timestamp_opt(command.last_run.unwrap(), 0).unwrap(),
-                            )
-                            .num_minutes(),
-                    )
-                    .to_std()
-                    .unwrap(),
-                )
-                .to_string()
-                .split(' ')
-                .take(2)
-                .map(|s| {
-                    s.replace("years", "y")
-                        .replace("year", "y")
-                        .replace("months", "mo")
-                        .replace("month", "mo")
-                        .replace("days", "d")
-                        .replace("day", "d")
-                        .replace("hours", "h")
-                        .replace("hour", "h")
-                        .replace("minutes", "m")
-                        .replace("minute", "m")
-                        .replace("0s", "< 1m")
-                })
-                .collect::<Vec<String>>()
-                .join(" ");
+                let duration = format_time_since(command.last_run.unwrap());
 
                 let highlight = if self.settings.lightmode {
                     color::Fg(color::Blue).to_string()
@@ -785,6 +755,36 @@ impl<'a> Interface<'a> {
     fn is_screen_view_bottom(&self) -> bool {
         self.settings.interface_view == InterfaceView::Bottom
     }
+}
+
+pub(crate) fn format_time_since(secs: i64) -> String {
+    humantime::format_duration(
+        Duration::minutes(
+            Utc::now()
+                .signed_duration_since(Utc.timestamp_opt(secs, 0).unwrap())
+                .num_minutes(),
+        )
+        .to_std()
+        .unwrap(),
+    )
+    .to_string()
+    .split(' ')
+    .take(2)
+    .map(|s| {
+        s.replace("years", "y")
+            .replace("year", "y")
+            .replace("months", "mo")
+            .replace("month", "mo")
+            .replace("days", "d")
+            .replace("day", "d")
+            .replace("hours", "h")
+            .replace("hour", "h")
+            .replace("minutes", "m")
+            .replace("minute", "m")
+            .replace("0s", "< 1m")
+    })
+    .collect::<Vec<String>>()
+    .join(" ")
 }
 
 // TODO:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod command_input;
 pub mod fake_typer;
 pub mod fixed_length_grapheme_string;
+pub mod fzf;
 pub mod history;
 pub mod history_cleaner;
 pub mod init;
@@ -14,4 +15,3 @@ pub mod simplified_command;
 pub mod trainer;
 pub mod training_cache;
 pub mod training_sample_generator;
-pub mod fzf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod simplified_command;
 pub mod trainer;
 pub mod training_cache;
 pub mod training_sample_generator;
+pub mod fzf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn handle_init(settings: &Settings) {
     Init::new(&settings.init_mode);
 }
 
-fn handle_fzf(settings: &Settings) {
+fn handle_fzf_show(settings: &Settings) {
     let history = History::load(settings.history_format);
     history.build_cache_table(
         &settings.dir,
@@ -114,6 +114,11 @@ fn handle_fzf(settings: &Settings) {
         settings.limit,
     );
     mcfly::fzf::run(&history, &settings.result_sort, settings.fzf_zero_separated)
+}
+
+fn handle_fzf_select(settings: &Settings) {
+    let history = History::load(settings.history_format);
+    history.record_selected_from_ui(&settings.command, &settings.session_id, &settings.dir);
 }
 
 fn main() {
@@ -135,8 +140,11 @@ fn main() {
         Mode::Init => {
             handle_init(&settings);
         }
-        Mode::Fzf => {
-            handle_fzf(&settings);
+        Mode::FzfShow => {
+            handle_fzf_show(&settings);
+        }
+        Mode::FzfSelect => {
+            handle_fzf_select(&settings);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,19 @@ fn handle_init(settings: &Settings) {
     Init::new(&settings.init_mode);
 }
 
+fn handle_fzf(settings: &Settings) {
+    let history = History::load(settings.history_format);
+    history.build_cache_table(
+        &settings.dir,
+        &Some(settings.session_id.to_owned()),
+        None,
+        None,
+        None,
+        settings.limit,
+    );
+    mcfly::fzf::run(&history, &settings.result_sort, settings.fzf_zero_separated)
+}
+
 fn main() {
     let settings = Settings::parse_args();
 
@@ -121,6 +134,9 @@ fn main() {
         }
         Mode::Init => {
             handle_init(&settings);
+        }
+        Mode::Fzf => {
+            handle_fzf(&settings);
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -488,13 +488,13 @@ impl Settings {
                 }
             }
 
-            ("fzf", Some(fzf_matches)) => {                
+            ("fzf", Some(fzf_matches)) => {
                 settings.result_sort = match fzf_matches.value_of("sort") {
                     Some("RANK") => ResultSort::Rank,
                     Some("LAST_RUN") => ResultSort::LastRun,
                     _ => settings.result_sort,
                 };
-                
+
                 settings.fzf_zero_separated = fzf_matches.is_present("null");
 
                 settings.mode = Mode::Fzf;


### PR DESCRIPTION
This pull request adds an option to use [fzf](https://github.com/junegunn/fzf) as the front-end UI, addressing issue #158 

If the environment variable `MCFLY_FZF` is defined at init time, then the fzf UI will be bound to Ctrl+R rather than the mcfly interface

This adds fzf support by:
1. Make a command `mcfly fzf` which just prints the command history as text to stdout
2. Modify the binding code in the shell init scripts so that if `MCFLY_FZF` is defined then Ctrl+R will instead run a copy of fzf reading its input from the `mcfly fzf` command with reasonable UI defaults

The only limitations of note are:
1. The MCFLY_FZF variable is only evaluated at init time. Due to the way that bash Ctrl+R is handled, it's not clear how to make the Ctrl+R binding change if the user sets MCFLY_FZF after init. 
     - It looks doable to have hot-reload of MCFLY_FZF in zsh and fish, but this binding in mcfly.bash seems hard to make support hot-reloading: https://github.com/cantino/mcfly/blob/master/mcfly.bash#L70-L76
2. Deletion is not supported within the fzf interface, though running `mcfly search` manually should work fine

