### PR TITLE
update version to match SHA

### DIFF
--- a/pkg/brew/mcfly.rb
+++ b/pkg/brew/mcfly.rb
@@ -7,7 +7,7 @@
 #   brew untap cantino/mcfly
 
 class Mcfly < Formula
-  version 'v0.6.1'
+  version 'v0.7.0'
   desc "McFly"
   homepage "https://github.com/cantino/mcfly"
 


### PR DESCRIPTION
Closes #312

I think this should fix the error being received to match the updated SHA256.

Validated the SHA locally to the assets in the release