### PR TITLE
Add forward-compatibility check for database schema

### DIFF
--- a/src/history/schema.rs
+++ b/src/history/schema.rs
@@ -24,7 +24,7 @@ pub fn migrate(connection: &Connection) {
 
     if current_version > CURRENT_SCHEMA_VERSION {
         panic!(
-            "McFly error: Database schema version ({}) is newer than the max version supported by this binary ({})",
+            "McFly error: Database schema version ({}) is newer than the max version supported by this binary ({}). You should update mcfly.",
             current_version,
             CURRENT_SCHEMA_VERSION,
         );

--- a/src/history/schema.rs
+++ b/src/history/schema.rs
@@ -22,6 +22,14 @@ pub fn migrate(connection: &Connection) {
         .unwrap_or_else(|err| panic!("McFly error: Query to work ({})", err))
         .unwrap_or(0);
 
+    if current_version > CURRENT_SCHEMA_VERSION {
+        panic!(
+            "McFly error: Database schema version ({}) is newer than the max version supported by this binary ({})",
+            current_version,
+            CURRENT_SCHEMA_VERSION,
+        );
+    }
+
     if current_version < CURRENT_SCHEMA_VERSION {
         print!(
             "McFly: Upgrading McFly DB to version {}, please wait...",


### PR DESCRIPTION
This adds an extra safety check in case mcfly encounters a schema newer than it knows how to deal with. 

The main motivation is to provide safety for users of my [`mcfly-fzf`](https://github.com/bnprks/mcfly-fzf) companion tool. This way users will see an obvious error if the DB schema used by their `mcfly` binary somehow is off from the schema used by their `mcfly-fzf` binary.