### PR TITLE
Add customizable prompt with $MCFLY_PROMPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ When suggesting a command, McFly takes into consideration:
 * Add below code to your zshrc.
 
     ```zsh
-    zinit ice lucid wait"0a" from"gh-r" as"program" atload'eval "$(mcfly init zsh)"' 
-    zinit light cantino/mcfly 
+    zinit ice lucid wait"0a" from"gh-r" as"program" atload'eval "$(mcfly init zsh)"'
+    zinit light cantino/mcfly
     ```
 * It will download mcfly and install for you.
 * `$(mcfly init zsh)` will be executed after prompt
@@ -310,6 +310,19 @@ export MCFLY_RESULTS_SORT=LAST_RUN
 fish:
 ```bash
 set -gx MCFLY_RESULTS_SORT LAST_RUN
+```
+
+### Custom Prompt
+To change the prompt, set `MCFLY_PROMPT` (default: `$`).
+
+bash / zsh:
+```bash
+export MCFLY_PROMPT="❯"
+```
+
+fish:
+```bash
+set -gx MCFLY_PROMPT "❯"
 ```
 
 ### Database Location

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -171,7 +171,7 @@ impl<'a> Interface<'a> {
         let prompt_line_index = self.prompt_line_index();
         write!(
             screen,
-            "{}{}{}$ {}",
+            "{}{}{}{} {}",
             if self.settings.lightmode {
                 color::Fg(color::Black).to_string()
             } else {
@@ -179,6 +179,7 @@ impl<'a> Interface<'a> {
             },
             cursor::Goto(1, self.prompt_line_index()),
             clear::CurrentLine,
+            self.settings.prompt,
             self.input
         )
         .unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,7 @@ pub struct Settings {
     pub interface_view: InterfaceView,
     pub result_sort: ResultSort,
     pub disable_menu: bool,
+    pub prompt: String,
 }
 
 impl Default for Settings {
@@ -115,6 +116,7 @@ impl Default for Settings {
             interface_view: InterfaceView::Top,
             result_sort: ResultSort::Rank,
             disable_menu: false,
+            prompt: String::from("$"),
         }
     }
 }
@@ -339,6 +341,10 @@ impl Settings {
             Ok("vim") => KeyScheme::Vim,
             _ => KeyScheme::Emacs,
         };
+
+        if let Ok(prompt) = env::var("MCFLY_PROMPT") {
+            settings.prompt = prompt;
+        }
 
         settings
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -343,7 +343,9 @@ impl Settings {
         };
 
         if let Ok(prompt) = env::var("MCFLY_PROMPT") {
-            settings.prompt = prompt;
+            if prompt.chars().count() == 1 {
+                settings.prompt = prompt;
+            }
         }
 
         settings


### PR DESCRIPTION
If `MCFLY_PROMPT` is set, it is used as the prompt, but if not it defaults to `$`. Fixes #324.