### PR TITLE
Add option to disable command running

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -69,7 +69,11 @@ impl MenuMode {
             }
         }
 
-        menu_text.push_str("⏎ - Run | TAB - Edit | ");
+        if interface.settings.disable_run_command {
+            menu_text.push_str("⏎, TAB - Edit | ");
+        } else {
+            menu_text.push_str("⏎ - Run | TAB - Edit | ");
+        }
 
         match interface.result_sort {
             ResultSort::Rank => menu_text.push_str("F1 - Switch Sort to Time | "),
@@ -463,7 +467,7 @@ impl<'a> Interface<'a> {
     fn select_with_emacs_key_scheme(&mut self, k: Key) -> bool {
         match k {
             Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
-                self.run = true;
+                self.run = !self.settings.disable_run_command;
                 self.accept_selection();
                 return true;
             }
@@ -544,7 +548,7 @@ impl<'a> Interface<'a> {
         if self.in_vim_insert_mode {
             match k {
                 Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
-                    self.run = true;
+                    self.run = !self.settings.disable_run_command;
                     self.accept_selection();
                     return true;
                 }
@@ -603,7 +607,7 @@ impl<'a> Interface<'a> {
         } else {
             match k {
                 Key::Char('\n') | Key::Char('\r') | Key::Ctrl('j') => {
-                    self.run = true;
+                    self.run = ! self.settings.disable_run_command;
                     self.accept_selection();
                     return true;
                 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,7 @@ pub struct Settings {
     pub interface_view: InterfaceView,
     pub result_sort: ResultSort,
     pub disable_menu: bool,
+    pub disable_run_command: bool,
 }
 
 impl Default for Settings {
@@ -115,6 +116,7 @@ impl Default for Settings {
             interface_view: InterfaceView::Top,
             result_sort: ResultSort::Rank,
             disable_menu: false,
+            disable_run_command: false,
         }
     }
 }
@@ -334,6 +336,8 @@ impl Settings {
         settings.lightmode = is_env_var_truthy("MCFLY_LIGHT");
 
         settings.disable_menu = is_env_var_truthy("MCFLY_DISABLE_MENU");
+
+        settings.disable_run_command = is_env_var_truthy("MCFLY_DISABLE_RUN_COMMAND");
 
         settings.key_scheme = match env::var("MCFLY_KEY_SCHEME").as_ref().map(String::as_ref) {
             Ok("vim") => KeyScheme::Vim,


### PR DESCRIPTION
This patch adds a new option `MCFLY_DISABLE_RUN_COMMAND`, which disables all command runs in mcfly when enabled.

This is related to #284 - I have been using fzf-history for quite a while and have built muscle memory of using enter to select a history command line and edit it. Since I switched to mcfly, the new enter key to select and execute a command may accidentally fire up unexpected command runs. This had made a lot of close calls to me already - dangerous history commands like `rm` and removal API calls.

It's really hard to adapt after years of usage. So I think it might make sense to add an option to mcfly that could globally turn off any command runs to avoid any surprises. This should help others who are migrating from fzf-hisory as well.