### PR TITLE
Added basic customisation for menubar colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,34 @@ set -gx MCFLY_PROMPT "❯"
 ```
 Note that only single-character-prompts are allowed. setting `MCFLY_PROMPT` to `"<str>"` will reset it to the default prompt.
 
+### Custom Menubar Colors
+To change the background color of the menubar, set `MCFLY_MENU_BACKGROUND` (default: `blue`).
+To change the foreground color of the menubar, set `MCFLY_MENU_FOREGROUND` (default: `white`).
+
+bash / zsh:
+```bash
+export MCFLY_MENU_BACKGROUND=green
+export MCFLY_MENU_FOREGROUND=black
+```
+
+fish:
+```bash
+set -gx MCFLY_MENU_BACKGROUND green
+set -gx MCFLY_MENU_FOREGROUND black
+```
+
+The following colors are supported:
+| Light       | Dark           |
+| :---------- | :------------- |
+| `dark_grey` | `black`        |
+| `red`       | `dark_red`     |
+| `green`     | `dark_green`   |
+| `yellow`    | `dark_yellow`  |
+| `blue`      | `dark_blue`    |
+| `magenta`   | `dark_magenta` |
+| `cyan`      | `dark_cyan`    |
+| `white`     | `grey`         |
+
 ### Database Location
 
 McFly stores its SQLite database in the standard location for the OS. On OS X, this is in `~/Library/Application Support/McFly` and on Linux it is in `$XDG_DATA_DIR/mcfly/history.db` (default would be `~/.local/share/mcfly/history.db`). For legacy support, if `~/.mcfly/` exists, it is used instead.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -85,9 +85,9 @@ impl MenuMode {
         menu_text
     }
 
-    fn bg(&self) -> Color {
+    fn bg(&self, menu_background: Color) -> Color {
         match *self {
-            MenuMode::Normal => Color::Blue,
+            MenuMode::Normal => menu_background,
             MenuMode::ConfirmDelete => Color::Red,
         }
     }
@@ -160,8 +160,8 @@ impl<'a> Interface<'a> {
             cursor::Hide,
             cursor::MoveTo(0, self.info_line_index()),
             Clear(ClearType::CurrentLine),
-            SetBackgroundColor(self.menu_mode.bg()),
-            SetForegroundColor(Color::White),
+            SetBackgroundColor(self.menu_mode.bg(self.settings.menu_background)),
+            SetForegroundColor(self.settings.menu_foreground),
             cursor::MoveTo(1, self.info_line_index()),
             Print(format!(
                 "{text:width$}",

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use crate::cli::{Cli, SubCommand};
 use crate::shell_history;
 use clap::Parser;
+use crossterm::style::Color;
 use directories_next::{ProjectDirs, UserDirs};
 use std::env;
 use std::path::PathBuf;
@@ -88,6 +89,8 @@ pub struct Settings {
     pub disable_menu: bool,
     pub prompt: String,
     pub disable_run_command: bool,
+    pub menu_background: Color,
+    pub menu_foreground: Color,
 }
 
 impl Default for Settings {
@@ -119,6 +122,8 @@ impl Default for Settings {
             disable_menu: false,
             prompt: String::from("$"),
             disable_run_command: false,
+            menu_background: Color::Blue,
+            menu_foreground: Color::White,
         }
     }
 }
@@ -153,6 +158,16 @@ impl Settings {
                 _ => ResultSort::Rank,
             },
             _ => ResultSort::Rank,
+        };
+
+        settings.menu_background = match env::var("MCFLY_MENU_BACKGROUND") {
+            Ok(val) => Color::try_from(val.as_str()).unwrap_or(Settings::default().menu_background),
+            _ => Settings::default().menu_background,
+        };
+
+        settings.menu_foreground = match env::var("MCFLY_MENU_FOREGROUND") {
+            Ok(val) => Color::try_from(val.as_str()).unwrap_or(Settings::default().menu_foreground),
+            _ => Settings::default().menu_foreground,
         };
 
         settings.session_id = cli.session_id.unwrap_or_else(||


### PR DESCRIPTION
#156 looks promising, but hasn't seen much action in the last 2 years. So I
made a quick and simple way to customize the foreground and background colors of the menubar using env vars.

Haven't used rust too much, so lmk if I can improve on anything