### PR TITLE
fix: added sudo to installation via install script readme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ When suggesting a command, McFly takes into consideration:
 
 ### Installing using our install script
 
-1. `curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sh -s -- --git cantino/mcfly`
+1. `curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sudo sh -s -- --git cantino/mcfly`
 
 2. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish` file, respectively:
 


### PR DESCRIPTION
Currently when trying to install via the installation script command in the README we fail with a permission denied.

This is due to the default installation location `/usr/local/bin` in the `install.sh`. Adding sudo to the command will fix this issue.