### PR TITLE
zsh: always set MCFLY_HISTORY in main script

### DIFF
--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -24,9 +24,7 @@ if [[ -o interactive ]]; then
   setopt interactive_comments   # allow comments in interactive shells (like Bash does)
 
   # McFly's temporary, per-session history file.
-  if [[ ! -f "${MCFLY_HISTORY}" ]]; then
-    export MCFLY_HISTORY=$(command mktemp ${TMPDIR:-/tmp}/mcfly.XXXXXXXX)
-  fi
+  export MCFLY_HISTORY=$(command mktemp ${TMPDIR:-/tmp}/mcfly.XXXXXXXX)
 
   # Check if we need to use extended history
   if [[ -o extendedhistory ]]; then


### PR DESCRIPTION
When using McFly with terminal multiplexers such as Zellij, McFly will reuse `MCFLY_HISTORY` from the parent shell causing an issue if multiple panes are launched together using layouts.
Always set `MCFLY_HISTORY` in the main shell init script to ensure that `MCFLY_HISTORY` is unique in the child shells.

Fixes #355.