### PR TITLE
Fish private mode support

### DIFF
--- a/mcfly.fish
+++ b/mcfly.fish
@@ -31,7 +31,9 @@ if test "$__MCFLY_LOADED" != "loaded"
   end
 
   function __mcfly_add_command -d 'Add run commands to McFly database' -e fish_postexec
-    # First, retain return code of last command before we lose it
+    # Check for the private mode
+    test -n "$fish_private_mode"; and return
+    # Retain return code of last command before we lose it
     set -l last_status $status
     # Handle first call of this function after sourcing mcfly.fish, when the old PWD won't be set
     set -q __MCFLY_OLD_PWD; or set -g __MCFLY_OLD_PWD "$PWD"


### PR DESCRIPTION
This PR adds Fish private mode support by updating the Fish init script. It simply forbids saving command history while in the mode.

Thus it resolves #354.

Yet it does not forbid accessing the McFly history, and it is contrary to Fish’s behavior. But it is out of #354 scope, and I do not think it is a problem since hitting <kbd>CTRL+R</kbd> is a conscious action with the expectable outcome.