### PR TITLE
Create draft releases in pipeline

### DIFF
--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: false
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
Github sends out an email on creating/publishing a release (Watch -> Custom -> releases) and that email contains whatever is at that point in the release description. As the pipeline currently creates a release without a description the email is mostly empty. As the changelog is added manually later, lets only create a draft release which can be "published" after adding the changelog. The release email then contains a proper changelog entry.