### PR TITLE
Append history to dummy file for compatibility

### DIFF
--- a/mcfly.ps1
+++ b/mcfly.ps1
@@ -10,6 +10,8 @@ $null = New-Module mcfly {
     # Get history file and make a dummy file for psreadline (hopefully after it has loaded the real history file to its in memory history)
     $env:HISTFILE = $null -eq $env:HISTFILE -or "" -eq $env:HISTFILE ? (Get-PSReadLineOption).HistorySavePath : $env:HISTFILE;
     $psreadline_dummy = New-TemporaryFile
+    # Append history to dummy file for compatibility
+    Get-Content -Path $Env:HISTFILE | Out-File -FilePath $psreadline_dummy -Force
     Set-PSReadLineOption -HistorySavePath $psreadline_dummy.FullName
 
 


### PR DESCRIPTION
After changing `HistorySavePath` to a dummy file, PSReadline can only access newer history. For compatibility, we should make a copy as a dummy file instead of a new file.