### PR TITLE
fix(pwsh): fix command with argument searching

### DIFF
--- a/mcfly.ps1
+++ b/mcfly.ps1
@@ -105,7 +105,7 @@ $null = New-Module mcfly {
         $cursor = $null
         [Microsoft.PowerShell.PSConsoleReadline]::GetBufferState([ref]$line, [ref]$cursor)
         "#mcfly: $line" | Out-File -FilePath $env:MCFLY_HISTORY -Append
-        Invoke-McFly -CommandToComplete $line
+        Invoke-McFly -CommandToComplete "`"$line`""
     }
 
     Export-ModuleMember -Function @(


### PR DESCRIPTION
Quote current input line with quotes in PowerShell's init script, then pass it as a single argument to `mcfly search`
fix #382 