### PR TITLE
Allow colors to be configured via config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
+dependencies = [
+ "proc-macro2 1.0.70",
+ "quote 1.0.33",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,12 +150,24 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -259,6 +288,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.11",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +367,15 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
  "libc",
 ]
 
@@ -361,6 +448,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +495,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +520,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -422,6 +544,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,10 +567,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fallible-iterator"
@@ -477,6 +626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +669,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -524,7 +689,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -580,6 +745,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +797,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +840,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -688,9 +886,11 @@ dependencies = [
  "chrono",
  "chrono-systemd-time",
  "clap",
+ "config",
  "crossterm",
  "csv",
  "directories-next",
+ "dirs 5.0.1",
  "humantime",
  "itertools",
  "libc",
@@ -720,6 +920,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +935,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -799,6 +1015,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1069,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pest"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.70",
+ "quote 1.0.33",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -1040,6 +1323,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.4.1",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1346,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1103,12 +1408,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shellexpand"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -1206,6 +1531,61 @@ dependencies = [
  "num-derive",
  "num-traits",
 ]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
@@ -1407,6 +1787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "winnow"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e19b97e00a4d3db3cdb9b53c8c5f87151b5689b82cc86c2848cbdcccb2689b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1803,15 @@ checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ lto = true
 debug = true
 
 [dependencies]
+config = "0.14.0"
 chrono = "0.4"
 chrono-systemd-time = "0.3"
 csv = "1"
@@ -29,6 +30,7 @@ path-absolutize = "3.0.13"
 regex = { version = "1", default-features = false, features = ["perf", "std"] }
 shellexpand = "2.1"
 unicode-segmentation = "1.9"
+dirs = "5.0.1"
 
 [dependencies.rusqlite]
 version = "0.28"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -92,9 +92,9 @@ impl MenuMode {
         menu_text
     }
 
-    fn bg(&self) -> Color {
+    fn bg(&self, normal: Color) -> Color {
         match *self {
-            MenuMode::Normal => Color::Blue,
+            MenuMode::Normal => normal,
             MenuMode::ConfirmDelete => Color::Red,
         }
     }
@@ -170,8 +170,8 @@ impl<'a> Interface<'a> {
                 cursor::Hide,
                 cursor::MoveTo(0, self.info_line_index()),
                 Clear(ClearType::CurrentLine),
-                SetBackgroundColor(self.menu_mode.bg()),
-                SetForegroundColor(Color::White),
+                SetBackgroundColor(self.menu_mode.bg(self.settings.colors.menubar_bg)),
+                SetForegroundColor(self.settings.colors.menubar_fg),
                 cursor::MoveTo(1, self.info_line_index()),
                 Print(format!(
                     "{text:width$}",
@@ -187,9 +187,9 @@ impl<'a> Interface<'a> {
     fn prompt<W: Write>(&self, screen: &mut W) {
         let prompt_line_index = self.prompt_line_index();
         let fg = if self.settings.lightmode {
-            Color::Black
+            self.settings.colors.lightmode_colors.prompt
         } else {
-            Color::White
+            self.settings.colors.darkmode_colors.prompt
         };
         queue!(
             screen,
@@ -226,28 +226,28 @@ impl<'a> Interface<'a> {
         let mut index: usize = 0;
         for command in self.matches.iter() {
             let mut fg = if self.settings.lightmode {
-                Color::Black
+                self.settings.colors.lightmode_colors.results_fg
             } else {
-                Color::White
+                self.settings.colors.darkmode_colors.results_fg
             };
 
             let mut highlight = if self.settings.lightmode {
-                Color::DarkBlue
+                self.settings.colors.lightmode_colors.results_hl
             } else {
-                Color::DarkGreen
+                self.settings.colors.darkmode_colors.results_hl
             };
 
             let mut bg = Color::Reset;
 
             if index == self.selection {
                 if self.settings.lightmode {
-                    fg = Color::White;
-                    bg = Color::DarkGrey;
-                    highlight = Color::Grey;
+                    fg = self.settings.colors.lightmode_colors.results_selection_fg;
+                    bg = self.settings.colors.lightmode_colors.results_selection_bg;
+                    highlight = self.settings.colors.lightmode_colors.results_selection_hl;
                 } else {
-                    fg = Color::Black;
-                    bg = Color::White;
-                    highlight = Color::DarkGreen;
+                    fg = self.settings.colors.darkmode_colors.results_selection_fg;
+                    bg = self.settings.colors.darkmode_colors.results_selection_bg;
+                    highlight = self.settings.colors.darkmode_colors.results_selection_hl;
                 }
             }
 
@@ -310,9 +310,9 @@ impl<'a> Interface<'a> {
                 .join(" ");
 
                 let timing_color = if self.settings.lightmode {
-                    Color::DarkBlue
+                    self.settings.colors.lightmode_colors.timing
                 } else {
-                    Color::Blue
+                    self.settings.colors.darkmode_colors.timing
                 };
                 queue!(
                     screen,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use config;
+use config::Source;
 use mcfly::dumper::Dumper;
 use mcfly::fake_typer;
 use mcfly::history::History;
@@ -101,7 +103,18 @@ fn handle_dump(settings: &Settings) {
 }
 
 fn main() {
-    let settings = Settings::parse_args();
+    let mut settings = Settings::parse_args();
+
+    // load ~/.config/mcfly/config.toml
+    let configpath = dirs::home_dir()
+        .expect("Homedir not found")
+        .join(".config/mcfly/config.toml");
+    let config = config::File::from(configpath);
+    let config_map = config.collect();
+
+    if let Some(config_map) = config_map.ok() {
+        settings.merge_config(config_map);
+    }
 
     match settings.mode {
         Mode::Add => {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,8 +2,11 @@ use crate::cli::{Cli, DumpFormat, SortOrder, SubCommand};
 use crate::shell_history;
 use crate::time::parse_timestamp;
 use clap::Parser;
+use config::Value;
+use crossterm::style::Color;
 use directories_next::{ProjectDirs, UserDirs};
 use regex::Regex;
+use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -82,6 +85,38 @@ pub struct TimeRange {
 }
 
 #[derive(Debug)]
+pub struct Colors {
+    pub menubar_bg: Color,
+    pub menubar_fg: Color,
+    pub darkmode_colors: DarkModeColors,
+    pub lightmode_colors: LightModeColors,
+}
+
+#[derive(Debug)]
+pub struct DarkModeColors {
+    pub prompt: Color,
+    pub timing: Color,
+    pub results_fg: Color,
+    pub results_bg: Color,
+    pub results_hl: Color,
+    pub results_selection_fg: Color,
+    pub results_selection_bg: Color,
+    pub results_selection_hl: Color,
+}
+
+#[derive(Debug)]
+pub struct LightModeColors {
+    pub prompt: Color,
+    pub timing: Color,
+    pub results_fg: Color,
+    pub results_bg: Color,
+    pub results_hl: Color,
+    pub results_selection_fg: Color,
+    pub results_selection_bg: Color,
+    pub results_selection_hl: Color,
+}
+
+#[derive(Debug)]
 pub struct Settings {
     pub mode: Mode,
     pub debug: bool,
@@ -114,6 +149,7 @@ pub struct Settings {
     pub sort_order: SortOrder,
     pub pattern: Option<Regex>,
     pub dump_format: DumpFormat,
+    pub colors: Colors,
 }
 
 impl Default for Settings {
@@ -150,11 +186,186 @@ impl Default for Settings {
             sort_order: SortOrder::default(),
             pattern: None,
             dump_format: DumpFormat::default(),
+            colors: Colors {
+                menubar_bg: Color::Blue,
+                menubar_fg: Color::White,
+                darkmode_colors: DarkModeColors {
+                    prompt: Color::White,
+                    timing: Color::Blue,
+                    results_fg: Color::White,
+                    results_bg: Color::Black,
+                    results_hl: Color::Blue,
+                    results_selection_fg: Color::Black,
+                    results_selection_bg: Color::White,
+                    results_selection_hl: Color::DarkGreen,
+                },
+                lightmode_colors: LightModeColors {
+                    prompt: Color::Black,
+                    timing: Color::DarkBlue,
+                    results_fg: Color::Black,
+                    results_bg: Color::White,
+                    results_hl: Color::Blue,
+                    results_selection_fg: Color::White,
+                    results_selection_bg: Color::DarkGrey,
+                    results_selection_hl: Color::Grey,
+                },
+            },
         }
     }
 }
 
 impl Settings {
+    pub fn merge_config(&mut self, config_map: HashMap<String, Value>) {
+        let color_config = config_map.get("colors");
+
+        let menubar_config = color_config
+            .and_then(|v| v.clone().into_table().ok())
+            .and_then(|v| v.get("menubar").and_then(|v| v.clone().into_table().ok()));
+
+        if let Some(menubar_config) = menubar_config {
+            if let Some(menubar_bg) = menubar_config
+                .get("bg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.menubar_bg = menubar_bg;
+            }
+            if let Some(menubar_fg) = menubar_config
+                .get("fg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.menubar_fg = menubar_fg;
+            }
+        }
+
+        let darkmode_config = color_config
+            .and_then(|v| v.clone().into_table().ok())
+            .and_then(|v| v.get("darkmode").and_then(|v| v.clone().into_table().ok()));
+
+        if let Some(darkmode_config) = darkmode_config {
+            if let Some(prompt) = darkmode_config
+                .get("prompt")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.prompt = prompt;
+            }
+            if let Some(timing) = darkmode_config
+                .get("timing")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.timing = timing;
+            }
+            if let Some(results_fg) = darkmode_config
+                .get("results_fg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.results_fg = results_fg;
+            }
+            if let Some(results_bg) = darkmode_config
+                .get("results_bg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.results_bg = results_bg;
+            }
+            if let Some(results_hl) = darkmode_config
+                .get("results_hl")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.results_hl = results_hl;
+            }
+            if let Some(results_selection_fg) = darkmode_config
+                .get("results_selection_fg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.results_selection_fg = results_selection_fg;
+            }
+            if let Some(results_selection_bg) = darkmode_config
+                .get("results_selection_bg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.results_selection_bg = results_selection_bg;
+            }
+            if let Some(results_selection_hl) = darkmode_config
+                .get("results_selection_hl")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.darkmode_colors.results_selection_hl = results_selection_hl;
+            }
+        }
+
+        let lightmode_config = color_config
+            .and_then(|v| v.clone().into_table().ok())
+            .and_then(|v| v.get("lightmode").and_then(|v| v.clone().into_table().ok()));
+
+        if let Some(lightmode_config) = lightmode_config {
+            if let Some(prompt) = lightmode_config
+                .get("prompt")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.prompt = prompt;
+            }
+            if let Some(timing) = lightmode_config
+                .get("timing")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.timing = timing;
+            }
+            if let Some(results_fg) = lightmode_config
+                .get("results_fg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.results_fg = results_fg;
+            }
+            if let Some(results_bg) = lightmode_config
+                .get("results_bg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.results_bg = results_bg;
+            }
+            if let Some(results_hl) = lightmode_config
+                .get("results_hl")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.results_hl = results_hl;
+            }
+            if let Some(results_selection_fg) = lightmode_config
+                .get("results_selection_fg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.results_selection_fg = results_selection_fg;
+            }
+            if let Some(results_selection_bg) = lightmode_config
+                .get("results_selection_bg")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.results_selection_bg = results_selection_bg;
+            }
+            if let Some(results_selection_hl) = lightmode_config
+                .get("results_selection_hl")
+                .and_then(|v| v.clone().into_string().ok())
+                .and_then(|v| Color::from_str(v.as_str()).ok())
+            {
+                self.colors.lightmode_colors.results_selection_hl = results_selection_hl;
+            }
+        }
+    }
+
     pub fn parse_args() -> Settings {
         let cli = Cli::parse();
 


### PR DESCRIPTION
## What?

Allow the colors to be configured via `~/.config/mcfly/config.toml`. This can also serve as a starting point for other config options. It has settings for both dark-mode and light-mode colors.

Example (my current color config for dark background):

```toml
[colors]

[colors.menubar]
bg = "black"
fg = "red"

[colors.darkmode]
prompt = "cyan"
timing = "yellow"
results_selection_fg = "cyan"
results_selection_bg = "black"
results_selection_hl = "red"
```

## Why?

I love mcfly but the default colors aren't working for me. I thought it might be nice if they could be set in a config file. This adds that capability by reading a basic `colors` config in a `~/.config` file for mcfly. It's written such that any errors or missing config will silently just fall back to using the defaults, which I've kept the same.

## Caveats

Reads the config file each time mcfly is run so that does add some overhead. An alternative might be to have different hard-coded color modes that could be enabled by a command line flag. This would mean no file read but also that you'd be limited to the set of color modes that are supported. The Colors struct used in the project seems pretty limited to begin with though (i.e. there's not a huge number of options). Some colors also didn't work for me in some contexts (e.g. setting the menubar to certain colors didn't always work for me).

## Thoughts and Feedback

Please let me know if you have thoughts on better ways to do this, if you'd like to see more extensive testing, etc.