### PR TITLE
Update README with Windows/pwsh instructions, and use data_local_dir to use %LOCALAPPDATA% on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ When suggesting a command, McFly takes into consideration:
 
 1. Download the [latest release from GitHub](https://github.com/cantino/mcfly/releases).
 1. Install to a location in your `$PATH`. (For example, you could create a directory at `~/bin`, copy `mcfly` to this location, and add `export PATH="$PATH:$HOME/bin"` to your `.bashrc` / `.zshrc`, or run `set -Ua fish_user_paths "$HOME/bin"` for fish.)
-1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish` file, respectively:
+1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or Powershell profile file, respectively:
 
    Bash:
     ```bash
@@ -155,6 +155,12 @@ When suggesting a command, McFly takes into consideration:
     ```bash
     mcfly init fish | source
     ```
+
+    Powershell Core (pwsh)
+    ```powershell
+    Invoke-Expression -Command $(mcfly init powershell | out-string)
+    ```
+
 1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` or restart your terminal emulator.
 
 ### Install manually from source
@@ -179,7 +185,12 @@ When suggesting a command, McFly takes into consideration:
     ```bash
     mcfly init fish | source
     ```
-1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` or restart your terminal emulator.
+
+    Powershell Core (pwsh)
+    ```powershell
+    Invoke-Expression -Command $(mcfly init powershell | out-string)
+    ```
+1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` / `. $PROFILE` or restart your terminal emulator.
 
 ### Install by [Zinit](https://github.com/zdharma-continuum/zinit)
 
@@ -276,6 +287,11 @@ if [[ "$(defaults read -g AppleInterfaceStyle 2&>/dev/null)" != "Dark" ]]; then
 fi
 ```
 
+```powershell
+$env:MCFLY_LIGHT = "TRUE"
+```
+
+
 
 ### VIM Key Scheme
 By default Mcfly uses an `emacs` inspired key scheme. If you would like to switch to the `vim` inspired key scheme, set the environment variable `MCFLY_KEY_SCHEME`.
@@ -288,6 +304,11 @@ export MCFLY_KEY_SCHEME=vim
 fish:
 ```bash
 set -gx MCFLY_KEY_SCHEME vim
+```
+
+powershell
+```powershell
+$env:MCFLY_KEY_SCHEME="vim"
 ```
 
 ### Fuzzy Searching
@@ -303,6 +324,10 @@ fish:
 set -gx MCFLY_FUZZY 2
 ```
 
+```powershell
+$env:MCFLY_FUZZY=2
+```
+
 ### Results Count
 To change the maximum number of results shown, set `MCFLY_RESULTS` (default: 10).
 
@@ -316,6 +341,10 @@ fish:
 set -gx MCFLY_RESULTS 50
 ```
 
+```powershell
+$env:MCFLY_RESULTS=50
+```
+
 ### Delete without confirmation
 To delete without confirmation, set `MCFLY_DELETE_WITHOUT_CONFIRM` to true.
 
@@ -327,6 +356,10 @@ export MCFLY_DELETE_WITHOUT_CONFIRM=true
 fish:
 ```bash
 set -gx MCFLY_DELETE_WITHOUT_CONFIRM true
+```
+
+```powershell
+$env:MCFLY_DELETE_WITHOUT_CONFIRM="true"
 ```
 
 ### Interface view
@@ -343,6 +376,10 @@ fish:
 set -gx MCFLY_INTERFACE_VIEW BOTTOM
 ```
 
+```powershell
+$env:MCFLY_INTERFACE_VIEW="BOTTOM"
+```
+
 ### Disable menu interface
 To disable the menu interface, set the environment variable `MCFLY_DISABLE_MENU`.
 
@@ -355,6 +392,11 @@ fish:
 ```bash
 set -gx MCFLY_DISABLE_MENU TRUE
 ```
+
+```powershell
+$env:MCFLY_DISABLE_MENU=true
+ ```
+
 
 ### Results sorting
 To change the sorting of results shown, set `MCFLY_RESULTS_SORT` (default: RANK).

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ When suggesting a command, McFly takes into consideration:
 
 1. Download the [latest release from GitHub](https://github.com/cantino/mcfly/releases).
 1. Install to a location in your `$PATH`. (For example, you could create a directory at `~/bin`, copy `mcfly` to this location, and add `export PATH="$PATH:$HOME/bin"` to your `.bashrc` / `.zshrc`, or run `set -Ua fish_user_paths "$HOME/bin"` for fish.)
-1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or Powershell profile script, respectively:
+1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`, respectively:
 
    Bash:
     ```bash
@@ -155,12 +155,7 @@ When suggesting a command, McFly takes into consideration:
     mcfly init fish | source
     ```
 
-   Powershell Core (pwsh)
-    ```powershell
-    Invoke-Expression -Command $(mcfly init powershell | out-string)
-    ```
-
-1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` / `. $PROFILE` or restart your terminal emulator.
+1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` or restart your terminal emulator.
 
 ### Install manually from source (macOS, Linux, or Windows)
 
@@ -168,7 +163,7 @@ When suggesting a command, McFly takes into consideration:
 1. Run `git clone https://github.com/cantino/mcfly` and `cd mcfly`
 1. Run `cargo install --path .`
 1. Ensure `~/.cargo/bin` is in your `$PATH`.
-1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish` file, respectively:
+1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or powershell `$PROFILE`, respectively:
 
    Bash:
     ```bash

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ fish:
 set -gx MCFLY_LIGHT TRUE
 ```
 
+powershell:
+```powershell
+$env:MCFLY_LIGHT = "TRUE"
+```
+
 Tip: on macOS you can use the following snippet for color scheme to be configured based on system-wide settings:
 
 bash / zsh:
@@ -280,10 +285,6 @@ bash / zsh:
 if [[ "$(defaults read -g AppleInterfaceStyle 2&>/dev/null)" != "Dark" ]]; then
     export MCFLY_LIGHT=TRUE
 fi
-```
-
-```powershell
-$env:MCFLY_LIGHT = "TRUE"
 ```
 
 ### VIM Key Scheme
@@ -299,7 +300,7 @@ fish:
 set -gx MCFLY_KEY_SCHEME vim
 ```
 
-powershell
+powershell:
 ```powershell
 $env:MCFLY_KEY_SCHEME="vim"
 ```
@@ -317,6 +318,7 @@ fish:
 set -gx MCFLY_FUZZY 2
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_FUZZY=2
 ```
@@ -334,6 +336,7 @@ fish:
 set -gx MCFLY_RESULTS 50
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_RESULTS=50
 ```
@@ -351,6 +354,7 @@ fish:
 set -gx MCFLY_DELETE_WITHOUT_CONFIRM true
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_DELETE_WITHOUT_CONFIRM="true"
 ```
@@ -369,6 +373,7 @@ fish:
 set -gx MCFLY_INTERFACE_VIEW BOTTOM
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_INTERFACE_VIEW="BOTTOM"
 ```
@@ -386,6 +391,7 @@ fish:
 set -gx MCFLY_DISABLE_MENU TRUE
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_DISABLE_MENU=true
  ```
@@ -404,6 +410,7 @@ fish:
 set -gx MCFLY_RESULTS_SORT LAST_RUN
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_RESULTS_SORT="LAST_RUN"
  ```
@@ -421,6 +428,7 @@ fish:
 set -gx MCFLY_PROMPT "❯"
 ```
 
+powershell:
 ```powershell
 $env:MCFLY_PROMPT=">"
  ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When suggesting a command, McFly takes into consideration:
 
 ## Installation
 
-### Install with Homebrew (on OS X or Linux)
+### Install with Homebrew (on macOS or Linux)
 
 1. Install `mcfly`:
     ```bash
@@ -73,7 +73,7 @@ When suggesting a command, McFly takes into consideration:
     ```
 1. Remove the lines you added to `~/.bashrc` / `~/.zshrc` / `~/.config/fish/config.fish`.
 
-### Install with MacPorts (on OS X)
+### Install with MacPorts (on macOS)
 
 1. Update the ports tree
     ```bash
@@ -109,7 +109,7 @@ When suggesting a command, McFly takes into consideration:
     ```
 1. Remove the lines you added to `~/.bashrc` / `~/.zshrc` / `~/.config/fish/config.fish`.
 
-### Installing using our install script
+### Installing using our install script (macOS or Linux)
 
 1. `curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sh -s -- --git cantino/mcfly` (or, if the current user doesn't have permissions to edit /usr/local/bin, then use `sudo sh -s`.)
 
@@ -128,18 +128,17 @@ When suggesting a command, McFly takes into consideration:
    ```
 
    Fish:
-
    ```bash
    mcfly init fish | source
    ```
 
 3. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` or restart your terminal emulator.
 
-### Installing manually from GitHub
+### Installing manually from GitHub (macOS or Linux)
 
 1. Download the [latest release from GitHub](https://github.com/cantino/mcfly/releases).
 1. Install to a location in your `$PATH`. (For example, you could create a directory at `~/bin`, copy `mcfly` to this location, and add `export PATH="$PATH:$HOME/bin"` to your `.bashrc` / `.zshrc`, or run `set -Ua fish_user_paths "$HOME/bin"` for fish.)
-1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or Powershell profile file, respectively:
+1. Add the following to the end of your `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or Powershell profile script, respectively:
 
    Bash:
     ```bash
@@ -156,14 +155,14 @@ When suggesting a command, McFly takes into consideration:
     mcfly init fish | source
     ```
 
-    Powershell Core (pwsh)
+   Powershell Core (pwsh)
     ```powershell
     Invoke-Expression -Command $(mcfly init powershell | out-string)
     ```
 
-1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` or restart your terminal emulator.
+1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` / `. $PROFILE` or restart your terminal emulator.
 
-### Install manually from source
+### Install manually from source (macOS, Linux, or Windows)
 
 1. [Install Rust 1.40 or later](https://www.rust-lang.org/tools/install)
 1. Run `git clone https://github.com/cantino/mcfly` and `cd mcfly`
@@ -190,6 +189,7 @@ When suggesting a command, McFly takes into consideration:
     ```powershell
     Invoke-Expression -Command $(mcfly init powershell | out-string)
     ```
+
 1. Run `. ~/.bashrc` / `. ~/.zshrc` / `source ~/.config/fish/config.fish` / `. $PROFILE` or restart your terminal emulator.
 
 ### Install by [Zinit](https://github.com/zdharma-continuum/zinit)
@@ -290,8 +290,6 @@ fi
 ```powershell
 $env:MCFLY_LIGHT = "TRUE"
 ```
-
-
 
 ### VIM Key Scheme
 By default Mcfly uses an `emacs` inspired key scheme. If you would like to switch to the `vim` inspired key scheme, set the environment variable `MCFLY_KEY_SCHEME`.
@@ -397,7 +395,6 @@ set -gx MCFLY_DISABLE_MENU TRUE
 $env:MCFLY_DISABLE_MENU=true
  ```
 
-
 ### Results sorting
 To change the sorting of results shown, set `MCFLY_RESULTS_SORT` (default: RANK).
 Possible values `RANK` and `LAST_RUN`
@@ -412,6 +409,10 @@ fish:
 set -gx MCFLY_RESULTS_SORT LAST_RUN
 ```
 
+```powershell
+$env:MCFLY_RESULTS_SORT="LAST_RUN"
+ ```
+
 ### Custom Prompt
 To change the prompt, set `MCFLY_PROMPT` (default: `$`).
 
@@ -424,11 +425,16 @@ fish:
 ```bash
 set -gx MCFLY_PROMPT "❯"
 ```
+
+```powershell
+$env:MCFLY_PROMPT=">"
+ ```
+
 Note that only single-character-prompts are allowed. setting `MCFLY_PROMPT` to `"<str>"` will reset it to the default prompt.
 
 ### Database Location
 
-McFly stores its SQLite database in the standard location for the OS. On OS X, this is in `~/Library/Application Support/McFly` and on Linux it is in `$XDG_DATA_DIR/mcfly/history.db` (default would be `~/.local/share/mcfly/history.db`). For legacy support, if `~/.mcfly/` exists, it is used instead.
+McFly stores its SQLite database in the standard location for the OS. On OS X, this is in `~/Library/Application Support/McFly`, on Linux it is in `$XDG_DATA_DIR/mcfly/history.db` (default would be `~/.local/share/mcfly/history.db`), and on Windows, it is `%LOCALAPPDATA%\McFly\data\history.db`. For legacy support, if `~/.mcfly/` exists, it is used instead.
 
 ### Slow startup
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -643,7 +643,7 @@ impl Settings {
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_DATA_DIR
     pub fn mcfly_db_path() -> PathBuf {
-        let data_dir = Settings::mcfly_xdg_dir().data_dir().to_path_buf();
+        let data_dir = Settings::mcfly_xdg_dir().data_local_dir().to_path_buf();
 
         Settings::mcfly_base_path(data_dir).join(PathBuf::from("history.db"))
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -643,10 +643,8 @@ impl Settings {
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_DATA_DIR
     pub fn mcfly_db_path() -> PathBuf {
-
         let data_dir = Settings::mcfly_xdg_dir().data_dir().to_path_buf();
-        if data_dir.exists()
-        {
+        if data_dir.exists() {
             return Settings::mcfly_base_path(data_dir).join(PathBuf::from("history.db"));
         };
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -643,9 +643,15 @@ impl Settings {
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_DATA_DIR
     pub fn mcfly_db_path() -> PathBuf {
-        let data_dir = Settings::mcfly_xdg_dir().data_local_dir().to_path_buf();
 
-        Settings::mcfly_base_path(data_dir).join(PathBuf::from("history.db"))
+        let data_dir = Settings::mcfly_xdg_dir().data_dir().to_path_buf();
+        if data_dir.exists()
+        {
+            return Settings::mcfly_base_path(data_dir).join(PathBuf::from("history.db"));
+        };
+
+        let data_local_dir = Settings::mcfly_xdg_dir().data_local_dir().to_path_buf();
+        Settings::mcfly_base_path(data_local_dir).join(PathBuf::from("history.db"))
     }
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_DATA_DIR


### PR DESCRIPTION
Adds instructions for installing for Windows, and configuring for powershell.

Use [`data_local_dir`](https://docs.rs/directories-next/latest/directories_next/struct.ProjectDirs.html#method.data_local_dir) instead of [`data_dir`](https://docs.rs/directories-next/latest/directories_next/struct.ProjectDirs.html#method.data_dir) to use `C:\Users\username\AppData\Local` instead of `C:\Users\username\AppData\Roaming` to avoid syncing large DBs across machines. The path remains the same on Linux and Mac.

Also, updates references to OS X to macOS.