### PR TITLE
Wrong order of commands in mcfly.fish

### DIFF
--- a/mcfly.fish
+++ b/mcfly.fish
@@ -31,10 +31,10 @@ if test "$__MCFLY_LOADED" != "loaded"
   end
 
   function __mcfly_add_command -d 'Add run commands to McFly database' -e fish_postexec
-    # Check for the private mode
-    test -n "$fish_private_mode"; and return
     # Retain return code of last command before we lose it
     set -l last_status $status
+    # Check for the private mode
+    test -n "$fish_private_mode"; and return
     # Handle first call of this function after sourcing mcfly.fish, when the old PWD won't be set
     set -q __MCFLY_OLD_PWD; or set -g __MCFLY_OLD_PWD "$PWD"
 


### PR DESCRIPTION
Fixes wrong order of commands in __mcfly_add_command which prevented to retain return code of last command.