### PR TITLE
Add workflow to publish Windows x64 release

### DIFF
--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -142,3 +142,45 @@ jobs:
           asset_path: ${{ env.BIN }}.tar.gz
           asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip
+
+  win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - uses: actions/checkout@v2
+
+      - run: rustup.exe default
+      - run: rustup.exe target add ${{ matrix.target }}
+
+      - name: Build Release
+        run: cargo.exe build --target ${{ matrix.target }} --release
+
+      - name: Zip Binary
+        run: 7z a ${{ env.BIN }}.zip ./target/${{ matrix.target }}/release/${{ env.BIN }}.exe
+
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.zip
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.zip
+          asset_content_type: application/gzip


### PR DESCRIPTION
Adds a workflow to publish a Windows x64 .zip file. I tested it on my own fork and it seems to be working.