### PR TITLE
Avoid TIOCSTI on Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,10 @@ McFly stores its SQLite database in the standard location for the OS. On OS X, t
 
 If you have a very large history database and you notice that McFly launches slowly, you can set `MCFLY_HISTORY_LIMIT` to something like 10000 to limit how many records are considered when searching. In this example, McFly would search only the latest 10,000 entries.
 
+### Bash TIOCSTI
+
+Starting with Linux kernel version 6.2, some systems have disabled TIOCSTI (which McFly previously used to write the selected command). McFly works around this issue by using two "dummy" keybindings, which default to `Meta+1` and `Meta+2`. If you are using either of these for another purpose, you can set the `MCFLY_BASH_SEARCH_KEYBINDING` and `MCFLY_BASH_ACCEPT_LINE_KEYBINDING`, respectively, to something you are not using. If you would prefer to use the legacy TIOCSTI behavior, you can enable it by setting the `sysctl` variable `dev.tty.legacy_tiocsti` to `1` on your system and set the `MCFLY_USE_TIOCSTI` bash variable to `1`.
+
 ## HISTTIMEFORMAT
 
 McFly currently doesn't parse or use `HISTTIMEFORMAT`.

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ If you have a very large history database and you notice that McFly launches slo
 
 ### Bash TIOCSTI
 
-Starting with Linux kernel version 6.2, some systems have disabled TIOCSTI (which McFly previously used to write the selected command). McFly works around this issue by using two "dummy" keybindings, which default to `Meta+1` and `Meta+2`. If you are using either of these for another purpose, you can set the `MCFLY_BASH_SEARCH_KEYBINDING` and `MCFLY_BASH_ACCEPT_LINE_KEYBINDING`, respectively, to something you are not using. If you would prefer to use the legacy TIOCSTI behavior, you can enable it by setting the `sysctl` variable `dev.tty.legacy_tiocsti` to `1` on your system and set the `MCFLY_USE_TIOCSTI` bash variable to `1`.
+Starting with Linux kernel version 6.2, some systems have disabled TIOCSTI (which McFly previously used to write the selected command). McFly works around this issue by using two "dummy" keybindings, which default to `Meta+1` and `Meta+2`. If you are using either of these for another purpose, you can set the `MCFLY_BASH_SEARCH_KEYBINDING` and `MCFLY_BASH_ACCEPT_LINE_KEYBINDING`, respectively, to something you are not using. If you would prefer to use the legacy TIOCSTI behavior, you can enable it by setting the `sysctl` variable `dev.tty.legacy_tiocsti` to `1` on your system and set the `MCFLY_BASH_USE_TIOCSTI` bash variable to `1`.
 
 ## HISTTIMEFORMAT
 

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -7,8 +7,8 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
   # Setup MCFLY_HISTFILE and make sure it exists.
   export MCFLY_HISTFILE="${HISTFILE:-$HOME/.bash_history}"
-  export MCFLY_BASH_SEARCH_KEY=${MCFLY_BASH_SEARCH_KEY:-"\M-1"}
-  export MCFLY_BASH_ACCEPT_LINE_KEY=${MCFLY_BASH_ACCEPT_LINE_KEY:-"\M-2"}
+  export MCFLY_BASH_SEARCH_KEYBINDING=${MCFLY_BASH_SEARCH_KEYBINDING:-"\M-1"}
+  export MCFLY_BASH_ACCEPT_LINE_KEYBINDING=${MCFLY_BASH_ACCEPT_LINE_KEYBINDING:-"\M-2"}
   if [[ ! -r "${MCFLY_HISTFILE}" ]]; then
     echo "McFly: ${MCFLY_HISTFILE} does not exist or is not readable. Please fix this or set HISTFILE to something else before using McFly."
     return 1
@@ -64,7 +64,7 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
     # If the file doesn't exist, nothing was selected from mcfly, exit without binding accept-line
     if [ ! -f $MCFLY_OUTPUT ];
     then
-      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEY\":\"\""
+      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\":\"\""
       return
     fi;
     # Get the command and set the bash text to it, and move the cursor to the end of the line.
@@ -76,9 +76,9 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
     MCFLY_MODE=$(awk 'NR==1{$1=a; print substr($0, 2)}' $MCFLY_OUTPUT)
     if [ $MCFLY_MODE = run ];
     then
-      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEY\":accept-line"
+      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\":accept-line"
     else
-      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEY\":\"\""
+      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\":\"\""
     fi;
 
     rm -f $MCFLY_OUTPUT
@@ -98,9 +98,13 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
   if [[ $- =~ .*i.* ]]; then
     if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
       # shellcheck disable=SC2016
-      # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).
-      bind -x "\"$MCFLY_BASH_SEARCH_KEY\":\"mcfly_search\""
-      bind "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEY$MCFLY_BASH_ACCEPT_LINE_KEY\""
+      if [ $MCFLY_USE_TIOCSTI -ne "" ]; then
+        bind -x '"\C-r": "echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY ; READLINE_LINE= ; mcfly search"'
+      else
+        # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).
+        bind -x "\"$MCFLY_BASH_SEARCH_KEYBINDING\":\"mcfly_search\""
+        bind "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEYBINDING$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\""
+      fi
     else
       # The logic here is:
       #   1. Jump to the beginning of the edit buffer, add 'mcfly: ', and comment out the current line. We comment out the line

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -62,7 +62,7 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
     echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY
     mcfly search -o $MCFLY_OUTPUT
     # If the file doesn't exist, nothing was selected from mcfly, exit without binding accept-line
-    if [ ! -f $MCFLY_OUTPUT ];
+    if [[ ! -f $MCFLY_OUTPUT ]];
     then
       bind "\"$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\":\"\""
       return
@@ -74,7 +74,7 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
     # Get the mode and bind the accept-line key if the mode is run.
     MCFLY_MODE=$(awk 'NR==1{$1=a; print substr($0, 2)}' $MCFLY_OUTPUT)
-    if [ $MCFLY_MODE = run ];
+    if [[ $MCFLY_MODE == "run" ]];
     then
       bind "\"$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\":accept-line"
     else
@@ -98,7 +98,7 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
   if [[ $- =~ .*i.* ]]; then
     if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
       # shellcheck disable=SC2016
-      if [ $MCFLY_BASH_USE_TIOCSTI = 1 ]; then
+      if [[ $MCFLY_BASH_USE_TIOCSTI = 1 ]]; then
         bind -x '"\C-r": "echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY ; READLINE_LINE= ; mcfly search"'
       else
         # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -98,7 +98,7 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
   if [[ $- =~ .*i.* ]]; then
     if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
       # shellcheck disable=SC2016
-      if [ $MCFLY_USE_TIOCSTI -ne "" ]; then
+      if [ $MCFLY_BASH_USE_TIOCSTI = 1 ]; then
         bind -x '"\C-r": "echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY ; READLINE_LINE= ; mcfly search"'
       else
         # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -7,6 +7,8 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
   # Setup MCFLY_HISTFILE and make sure it exists.
   export MCFLY_HISTFILE="${HISTFILE:-$HOME/.bash_history}"
+  export MCFLY_BASH_SEARCH_KEY=${MCFLY_BASH_SEARCH_KEY:-"\M-1"}
+  export MCFLY_BASH_ACCEPT_LINE_KEY=${MCFLY_BASH_ACCEPT_LINE_KEY:-"\M-2"}
   if [[ ! -r "${MCFLY_HISTFILE}" ]]; then
     echo "McFly: ${MCFLY_HISTFILE} does not exist or is not readable. Please fix this or set HISTFILE to something else before using McFly."
     return 1
@@ -52,6 +54,37 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
     return ${exit_code} # Restore the original exit code by returning it.
   }
 
+  # Runs mcfly search with output to file, reads the output, and sets READLINE_LINE to the command.
+  # If the command is to be run, binds the MCFLY_KEYSTROKE2 to accept-line, otherwise binds it to nothing.
+  function mcfly_search {
+    # Get a temp file name but don't create the file - mcfly will create the file for us.
+    MCFLY_OUTPUT=$(mktemp --dry-run ${TMPDIR:-/tmp}/mcfly.output.XXXXXXXX)
+    echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY
+    mcfly search -o $MCFLY_OUTPUT
+    # If the file doesn't exist, nothing was selected from mcfly, exit without binding accept-line
+    if [ ! -f $MCFLY_OUTPUT ];
+    then
+      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEY\":\"\""
+      return
+    fi;
+    # Get the command and set the bash text to it, and move the cursor to the end of the line.
+    MCFLY_COMMAND=$(awk 'NR==2{$1=a; print substr($0, 2)}' $MCFLY_OUTPUT)
+    READLINE_LINE=$MCFLY_COMMAND
+    READLINE_POINT=${#READLINE_LINE}
+
+    # Get the mode and bind the accept-line key if the mode is run.
+    MCFLY_MODE=$(awk 'NR==1{$1=a; print substr($0, 2)}' $MCFLY_OUTPUT)
+    if [ $MCFLY_MODE = run ];
+    then
+      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEY\":accept-line"
+    else
+      bind "\"$MCFLY_BASH_ACCEPT_LINE_KEY\":\"\""
+    fi;
+
+    rm -f $MCFLY_OUTPUT
+    return $LAST_EXIT_CODE
+  }
+
   # Set $PROMPT_COMMAND run mcfly_prompt_command, preserving any existing $PROMPT_COMMAND.
   if [ -z "$PROMPT_COMMAND" ]
   then
@@ -65,7 +98,9 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
   if [[ $- =~ .*i.* ]]; then
     if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
       # shellcheck disable=SC2016
-      bind -x '"\C-r": "echo \#mcfly: ${READLINE_LINE[@]} >> $MCFLY_HISTORY ; READLINE_LINE= ; mcfly search"'
+      # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).
+      bind -x "\"$MCFLY_BASH_SEARCH_KEY\":\"mcfly_search\""
+      bind "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEY$MCFLY_BASH_ACCEPT_LINE_KEY\""
     else
       # The logic here is:
       #   1. Jump to the beginning of the edit buffer, add 'mcfly: ', and comment out the current line. We comment out the line


### PR DESCRIPTION
To avoid using TIOCSTI on bash, mcfly can utilize the readline bindings. However, `bind` only lets you bind _either_ a bash command / function _or_ a readline function, but we can bind Ctrl+R to two keybindings - one which runs mcfly and binds/unbinds the second key to the `accept-line` readline depending on if `enter` or `tab` is pressed. It's a bit of a hack, so there's an escape hatch if a user prefers to use TIOCSTI.