### PR TITLE
Feature: quick stats 📊

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,6 +150,16 @@ pub enum SubCommand {
             value_name = "top_cmd_min_size"
         )]
         command_limit: Option<i16>,
+
+        /// The number of "top-n" commands
+        #[arg(
+            value_name = "TOP_COMMAND_SIZE",
+            short,
+            long,
+            value_name = "top_cmd_size",
+            default_value_t = 10
+        )]
+        limit: i16,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,7 +141,16 @@ pub enum SubCommand {
     },
 
     /// Prints stats
-    Stats {},
+    Stats {
+        /// The minimum command size to be listed in the "top-n" commands
+        #[arg(
+            value_name = "TOP_COMMAND_MIN_SIZE",
+            short,
+            long,
+            value_name = "top_cmd_min_size"
+        )]
+        command_limit: Option<i16>,
+    },
 }
 
 #[derive(Clone, Copy, ValueEnum, Default)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -139,6 +139,9 @@ pub enum SubCommand {
         #[arg(long, short, value_enum, default_value_t)]
         format: DumpFormat,
     },
+
+    /// Prints stats
+    Stats {},
 }
 
 #[derive(Clone, Copy, ValueEnum, Default)]

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -677,7 +677,7 @@ impl History {
         }
     }
 
-    fn run_query<T, F>(&self, query: &str, params: &[(&str, &dyn ToSql)], f: F) -> Vec<T>
+    pub fn run_query<T, F>(&self, query: &str, params: &[(&str, &dyn ToSql)], f: F) -> Vec<T>
     where
         F: FnMut(&Row<'_>) -> rusqlite::Result<T>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod path_update_helpers;
 pub mod settings;
 pub mod shell_history;
 pub mod simplified_command;
+pub mod stats_generator;
 pub mod time;
 pub mod trainer;
 pub mod training_cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,10 @@ fn handle_dump(settings: &Settings) {
 
 fn handle_stats(settings: &Settings) {
     let history = History::load(settings.history_format);
-    let stats = StatsGenerator::new(&history).generate_stats(10, settings.stats_command_limit);
+    let stats = StatsGenerator::new(&history).generate_stats(
+        settings.stats_top_command_limit,
+        settings.stats_command_limit,
+    );
     println!("{}", stats);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use mcfly::dumper::Dumper;
 use mcfly::fake_typer;
 use mcfly::history::History;
@@ -6,10 +10,8 @@ use mcfly::interface::Interface;
 use mcfly::settings::Mode;
 use mcfly::settings::Settings;
 use mcfly::shell_history;
+use mcfly::stats_generator::StatsGenerator;
 use mcfly::trainer::Trainer;
-use std::fs;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn handle_addition(settings: &Settings) {
     let history = History::load(settings.history_format);
@@ -100,6 +102,12 @@ fn handle_dump(settings: &Settings) {
     Dumper::new(settings, &history).dump();
 }
 
+fn handle_stats(settings: &Settings) {
+    let history = History::load(settings.history_format);
+    let stats = StatsGenerator::new(&history).generate_stats(10);
+    println!("{}", stats);
+}
+
 fn main() {
     let mut settings = Settings::parse_args();
 
@@ -124,5 +132,6 @@ fn main() {
         Mode::Dump => {
             handle_dump(&settings);
         }
+        Mode::Stats => handle_stats(&settings),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn handle_dump(settings: &Settings) {
 
 fn handle_stats(settings: &Settings) {
     let history = History::load(settings.history_format);
-    let stats = StatsGenerator::new(&history).generate_stats(10);
+    let stats = StatsGenerator::new(&history).generate_stats(10, settings.stats_command_limit);
     println!("{}", stats);
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -152,6 +152,7 @@ pub struct Settings {
     pub pattern: Option<Regex>,
     pub dump_format: DumpFormat,
     pub colors: Colors,
+    pub stats_command_limit: Option<i16>,
 }
 
 impl Default for Settings {
@@ -212,6 +213,7 @@ impl Default for Settings {
                     results_selection_hl: Color::Grey,
                 },
             },
+            stats_command_limit: None,
         }
     }
 }
@@ -453,8 +455,9 @@ impl Settings {
                 settings.dump_format = format;
             }
 
-            SubCommand::Stats {} => {
+            SubCommand::Stats { command_limit } => {
                 settings.mode = Mode::Stats;
+                settings.stats_command_limit = command_limit;
             }
         }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,6 +22,7 @@ pub enum Mode {
     Move,
     Init,
     Dump,
+    Stats,
 }
 
 #[derive(Debug)]
@@ -450,6 +451,10 @@ impl Settings {
                 settings.sort_order = sort;
                 settings.pattern = regex;
                 settings.dump_format = format;
+            }
+
+            SubCommand::Stats {} => {
+                settings.mode = Mode::Stats;
             }
         }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -153,6 +153,7 @@ pub struct Settings {
     pub dump_format: DumpFormat,
     pub colors: Colors,
     pub stats_command_limit: Option<i16>,
+    pub stats_top_command_limit: i16,
 }
 
 impl Default for Settings {
@@ -214,6 +215,7 @@ impl Default for Settings {
                 },
             },
             stats_command_limit: None,
+            stats_top_command_limit: 10,
         }
     }
 }
@@ -455,9 +457,13 @@ impl Settings {
                 settings.dump_format = format;
             }
 
-            SubCommand::Stats { command_limit } => {
+            SubCommand::Stats {
+                command_limit,
+                limit,
+            } => {
                 settings.mode = Mode::Stats;
                 settings.stats_command_limit = command_limit;
+                settings.stats_top_command_limit = limit;
             }
         }
 

--- a/src/stats_generator.rs
+++ b/src/stats_generator.rs
@@ -85,13 +85,18 @@ impl<'a> StatsGenerator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use rusqlite::Connection;
+
     use crate::history::History;
-    use crate::settings::HistoryFormat;
+    use crate::network::Network;
     use crate::stats_generator::StatItem;
 
     #[test]
     fn empty_history() {
-        let history = History::load(HistoryFormat::Bash);
+        let history = History {
+            connection: Connection::open_in_memory().unwrap(),
+            network: Network::random(),
+        };
         let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
         let lines = stats_generator.generate_command_stats(10, Vec::new());
         assert_eq!(lines, "");
@@ -99,7 +104,10 @@ mod tests {
 
     #[test]
     fn partial_history() {
-        let history = History::load(HistoryFormat::Bash);
+        let history = History {
+            connection: Connection::open_in_memory().unwrap(),
+            network: Network::random(),
+        };
         let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
         let lines = stats_generator.generate_command_stats(
             3,
@@ -122,7 +130,10 @@ mod tests {
 
     #[test]
     fn full_history() {
-        let history = History::load(HistoryFormat::Bash);
+        let history = History {
+            connection: Connection::open_in_memory().unwrap(),
+            network: Network::random(),
+        };
         let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
         let lines = stats_generator.generate_command_stats(
             2,

--- a/src/stats_generator.rs
+++ b/src/stats_generator.rs
@@ -23,10 +23,10 @@ impl<'a> StatsGenerator<'a> {
         if count_history == 0 {
             return "No history, no stats!".to_string();
         }
-        lines.push_str(format!("📊 Quick stats:\n").as_mut_str());
+        lines.push_str("📊 Quick stats:\n");
         lines.push_str(format!("  - history has {:?} items ;\n", count_history).as_mut_str());
         let most_used_commands = self.most_used_commands(&limit);
-        lines.push_str(&*Self::generate_command_stats(
+        lines.push_str(&Self::generate_command_stats(
             self,
             limit,
             most_used_commands,
@@ -79,7 +79,7 @@ impl<'a> StatsGenerator<'a> {
             .run_query("select count(1) as n from commands", &[], |row| {
                 Ok(Count { count: row.get(0)? })
             });
-        vec.get(0).unwrap().count
+        vec.first().unwrap().count
     }
 }
 

--- a/src/stats_generator.rs
+++ b/src/stats_generator.rs
@@ -1,0 +1,145 @@
+use std::cmp::min;
+use std::ops::Add;
+
+use serde::Serialize;
+
+use crate::history::History;
+
+#[derive(Debug)]
+pub struct StatsGenerator<'a> {
+    history: &'a History,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StatItem {
+    cmd: String,
+    count: i64,
+}
+
+impl<'a> StatsGenerator<'a> {
+    pub fn generate_stats(&self, limit: i32) -> String {
+        let mut lines = "".to_owned();
+        let count_history = Self::count_commands_from_db_history(self);
+        if count_history == 0 {
+            return "No history, no stats!".to_string();
+        }
+        lines.push_str(format!("📊 Quick stats:\n").as_mut_str());
+        lines.push_str(format!("  - history has {:?} items ;\n", count_history).as_mut_str());
+        let most_used_commands = self.most_used_commands(&limit);
+        lines.push_str(&*Self::generate_command_stats(
+            self,
+            limit,
+            most_used_commands,
+        ));
+        lines
+    }
+
+    fn generate_command_stats(&self, limit: i32, stats: Vec<StatItem>) -> String {
+        let mut lines = "".to_owned();
+        if !stats.is_empty() {
+            lines.push_str(
+                format!(
+                    "  - {:?} first commands, sorted by occurrences:\n",
+                    min(limit, stats.len() as i32)
+                )
+                .as_mut_str(),
+            );
+            for item in stats {
+                if !item.cmd.trim().is_empty() {
+                    lines = lines.add(&*format!("    {:#} ({:?})\n", item.cmd, item.count));
+                }
+            }
+        }
+        lines
+    }
+
+    fn most_used_commands(&self, limit: &i32) -> Vec<StatItem> {
+        self
+            .history
+            .run_query("select substr(cmd,1,instr(cmd,' ')-1), count(1) as n from commands group by 1 order by 2 desc limit :limit ", &[
+                (":limit", &limit.to_owned()),
+            ], |row| {
+                Ok(StatItem {
+                    cmd: row.get(0)?,
+                    count: row.get(1)?,
+                })
+            })
+    }
+
+    #[inline]
+    pub fn new(history: &'a History) -> Self {
+        Self { history }
+    }
+    fn count_commands_from_db_history(&self) -> i32 {
+        struct Count {
+            count: i32,
+        }
+        let vec = self
+            .history
+            .run_query("select count(1) as n from commands", &[], |row| {
+                Ok(Count { count: row.get(0)? })
+            });
+        vec.get(0).unwrap().count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::history::History;
+    use crate::settings::HistoryFormat;
+    use crate::stats_generator::StatItem;
+
+    #[test]
+    fn empty_history() {
+        let history = History::load(HistoryFormat::Bash);
+        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
+        let lines = stats_generator.generate_command_stats(10, Vec::new());
+        assert_eq!(lines, "");
+    }
+
+    #[test]
+    fn partial_history() {
+        let history = History::load(HistoryFormat::Bash);
+        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
+        let lines = stats_generator.generate_command_stats(
+            3,
+            Vec::from([
+                StatItem {
+                    cmd: "git".to_string(),
+                    count: 10,
+                },
+                StatItem {
+                    cmd: "cargo".to_string(),
+                    count: 9,
+                },
+            ]),
+        );
+        assert_eq!(
+            lines,
+            "  - 2 first commands, sorted by occurrences:\n    git (10)\n    cargo (9)\n"
+        );
+    }
+
+    #[test]
+    fn full_history() {
+        let history = History::load(HistoryFormat::Bash);
+        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
+        let lines = stats_generator.generate_command_stats(
+            2,
+            Vec::from([
+                StatItem {
+                    cmd: "git".to_string(),
+                    count: 10,
+                },
+                StatItem {
+                    cmd: "cargo".to_string(),
+                    count: 9,
+                },
+            ]),
+        );
+        assert_eq!(
+            lines,
+            "  - 2 first commands, sorted by occurrences:\n    git (10)\n    cargo (9)\n"
+        );
+    }
+}


### PR DESCRIPTION
See https://github.com/cantino/mcfly/issues/330.

I propose this basic implementation. :blush: 
I introduced a few unit tests. Integration tests may be more useful.

See the [commit message](https://github.com/cantino/mcfly/pull/420/commits/7878c2aeec027a04fe84e73560bf0dd4ff6e7d73) for an example of output.

Note that the number of "first commands, sorted by occurrences" is hard-coded to 10. Should it be configurable from the command line?