### PR TITLE
Stats can now take --only-dir, --dirs, and --global-commands-to-ignore

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,24 +142,49 @@ pub enum SubCommand {
 
     /// Prints stats
     Stats {
-        /// The minimum command size to be listed in the "top-n" commands
+        /// The minimum command length to be listed in the "top-n" commands
         #[arg(
-            value_name = "TOP_COMMAND_MIN_SIZE",
+            value_name = "MIN_CMD_LENGTH",
             short,
             long,
-            value_name = "top_cmd_min_size"
+            value_name = "min_cmd_length",
+            default_value_t = 0
         )]
-        command_limit: Option<i16>,
+        min_cmd_length: i16,
 
         /// The number of "top-n" commands
         #[arg(
-            value_name = "TOP_COMMAND_SIZE",
+            value_name = "CMDS",
             short,
             long,
-            value_name = "top_cmd_size",
+            value_name = "cmds",
             default_value_t = 10
         )]
-        limit: i16,
+        cmds: i16,
+
+        /// Break down by top directories - defaults to 0, which doesn't limit by directory
+        #[arg(
+            value_name = "DIRS",
+            short,
+            long,
+            value_name = "dirs",
+            default_value_t = 0
+        )]
+        dirs: i16,
+
+        // Skip the top n commands when breaking down by directory
+        #[arg(
+            value_name = "GLOBAL_CMDS_TO_IGNORE",
+            short,
+            long,
+            value_name = "global_cmds_to_ignore",
+            default_value_t = 10
+        )]
+        global_commands_to_ignore: i16,
+
+        /// Only show commands from a given directory
+        #[arg(value_name = "ONLY_DIR", short, long)]
+        only_dir: Option<String>,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,10 +104,7 @@ fn handle_dump(settings: &Settings) {
 
 fn handle_stats(settings: &Settings) {
     let history = History::load(settings.history_format);
-    let stats = StatsGenerator::new(&history).generate_stats(
-        settings.stats_top_command_limit,
-        settings.stats_command_limit,
-    );
+    let stats = StatsGenerator::new(&history).generate_stats(settings);
     println!("{}", stats);
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -152,8 +152,11 @@ pub struct Settings {
     pub pattern: Option<Regex>,
     pub dump_format: DumpFormat,
     pub colors: Colors,
-    pub stats_command_limit: Option<i16>,
-    pub stats_top_command_limit: i16,
+    pub stats_min_cmd_length: i16,
+    pub stats_cmds: i16,
+    pub stats_dirs: i16,
+    pub stats_global_commands_to_ignore: i16,
+    pub stats_only_dir: Option<String>,
 }
 
 impl Default for Settings {
@@ -214,8 +217,11 @@ impl Default for Settings {
                     results_selection_hl: Color::Grey,
                 },
             },
-            stats_command_limit: None,
-            stats_top_command_limit: 10,
+            stats_min_cmd_length: 0,
+            stats_cmds: 10,
+            stats_dirs: 0,
+            stats_global_commands_to_ignore: 10,
+            stats_only_dir: None,
         }
     }
 }
@@ -458,12 +464,18 @@ impl Settings {
             }
 
             SubCommand::Stats {
-                command_limit,
-                limit,
+                min_cmd_length,
+                cmds,
+                dirs,
+                global_commands_to_ignore,
+                only_dir,
             } => {
                 settings.mode = Mode::Stats;
-                settings.stats_command_limit = command_limit;
-                settings.stats_top_command_limit = limit;
+                settings.stats_min_cmd_length = min_cmd_length;
+                settings.stats_cmds = cmds;
+                settings.stats_dirs = dirs;
+                settings.stats_global_commands_to_ignore = global_commands_to_ignore;
+                settings.stats_only_dir = only_dir;
             }
         }
 

--- a/src/stats_generator.rs
+++ b/src/stats_generator.rs
@@ -1,10 +1,10 @@
 use std::cmp::min;
-use std::ops::Add;
+use std::collections::HashMap;
 
-use regex::Regex;
 use serde::Serialize;
 
 use crate::history::History;
+use crate::settings::Settings;
 
 #[derive(Debug)]
 pub struct StatsGenerator<'a> {
@@ -13,218 +13,219 @@ pub struct StatsGenerator<'a> {
 
 #[derive(Debug, Clone, Serialize)]
 struct StatItem {
-    cmd: String,
+    cmd_tpl: String,
     count: i64,
+    dir: Option<String>,
 }
 
 impl<'a> StatsGenerator<'a> {
-    pub fn generate_stats(&self, limit: i16, command_limit: Option<i16>) -> String {
+    pub fn generate_stats(&self, settings: &Settings) -> String {
         let mut lines = "".to_owned();
-        let count_history = Self::count_commands_from_db_history(self);
+        let count_history = Self::count_commands_from_db_history(self, &settings.stats_only_dir);
         if count_history == 0 {
-            return "No history, no stats!".to_string();
+            return if settings.stats_only_dir.is_some() {
+                format!(
+                    "No history found in {:?}",
+                    &settings.stats_only_dir.as_ref().unwrap()
+                )
+            } else {
+                "No history found in the database".to_string()
+            };
         }
         lines.push_str("📊 Quick stats:\n");
-        lines.push_str(format!("  - history has {:?} items ;\n", count_history).as_mut_str());
-        let most_used_commands = self.most_used_commands(&limit, command_limit.unwrap_or(1));
+        if settings.stats_only_dir.is_some() {
+            lines.push_str(
+                format!(
+                    "  - history has {:?} items in {:?}\n",
+                    count_history,
+                    &settings.stats_only_dir.as_ref().unwrap()
+                )
+                .as_mut_str(),
+            );
+        } else {
+            lines.push_str(format!("  - history has {:?} items\n", count_history).as_mut_str());
+        }
+        let most_used_commands = self.most_used_commands(
+            settings.stats_cmds,
+            settings.stats_min_cmd_length,
+            settings.stats_dirs,
+            settings.stats_global_commands_to_ignore,
+            &settings.stats_only_dir,
+        );
         lines.push_str(&Self::generate_command_stats(
             self,
-            limit,
+            settings.stats_cmds,
             most_used_commands,
         ));
         lines
     }
 
-    fn generate_command_stats(&self, limit: i16, stats: Vec<StatItem>) -> String {
-        let mut lines = "".to_owned();
-        if !stats.is_empty() {
-            lines.push_str(
-                format!(
-                    "  - {:?} first commands, sorted by occurrences:\n",
-                    min(limit, stats.len() as i16)
-                )
-                .as_mut_str(),
-            );
-            let re = Regex::new("^(.*)/(.*)$").unwrap();
-            for item in &stats[..min(limit as usize, stats.len())] {
-                let cmd = item.clone().cmd;
-                if !cmd.trim().is_empty() {
-                    let relative_cmd = re.captures(&cmd).map(|dir_and_cmd| {
-                        format!(
-                            "{0} ({1})",
-                            dir_and_cmd.get(2).unwrap().as_str(),
-                            dir_and_cmd.get(1).unwrap().as_str()
-                        )
-                    });
-                    lines = lines.add(&*format!(
-                        "    {:#} ({:?})\n",
-                        relative_cmd.unwrap_or(cmd),
-                        item.count
-                    ));
-                }
+    fn generate_command_stats(&self, cmds: i16, stats: Vec<StatItem>) -> String {
+        let mut lines = String::new();
+        let mut directory_map: HashMap<Option<String>, Vec<&StatItem>> = HashMap::new();
+
+        // Group stats by directory
+        for item in &stats {
+            directory_map
+                .entry(item.dir.clone())
+                .or_default()
+                .push(item);
+        }
+
+        for (dir, items) in directory_map.iter() {
+            if let Some(dir_name) = dir {
+                lines.push_str(&format!("  - Directory: {}\n", dir_name));
+            } else {
+                lines.push_str(&format!(
+                    "  - {:?} top filtered commands, sorted by occurrence:\n",
+                    min(cmds, items.len() as i16)
+                ));
+            }
+
+            for item in &items[..min(cmds as usize, items.len())] {
+                lines.push_str(&format!("    {} ({})\n", item.cmd_tpl, item.count));
             }
         }
+
+        if lines.contains("QUOTED") || lines.contains("PATH") {
+            lines.push_str("  - (QUOTED and PATH indicate portions of a command that were removed for grouping)\n");
+        }
+
         lines
     }
 
-    fn most_used_commands(&self, limit: &i16, command_limit: i16) -> Vec<StatItem> {
-        self.history.run_query(
-            "select substr(cmd,1,instr(cmd,' ')-1), count(1) as n \
-                from commands \
-                where length(substr(cmd,1,instr(cmd,' ')-1)) >= :command_limit \
-                group by 1 \
-                order by 2 \
-                desc limit :limit",
-            &[
-                (":command_limit", &command_limit.to_owned()),
-                (":limit", &limit.to_owned()),
-            ],
-            |row| {
-                Ok(StatItem {
-                    cmd: row.get(0)?,
-                    count: row.get(1)?,
-                })
-            },
-        )
+    fn most_used_commands(
+        &self,
+        cmds: i16,
+        min_cmd_length: i16,
+        dirs: i16,
+        global_commands_to_ignore: i16,
+        only_dir: &Option<String>,
+    ) -> Vec<StatItem> {
+        if dirs > 0 || only_dir.is_some() {
+            let query = "
+            WITH DirectoryCounts AS (
+                SELECT
+                    dir,
+                    COUNT(*) AS cmd_count
+                FROM
+                    commands
+                WHERE
+                    length(cmd_tpl) >= :min_cmd_length
+                    AND (:dir_filter_off OR dir = :only_dir)
+                GROUP BY
+                    dir
+                ORDER BY
+                    cmd_count DESC
+                LIMIT
+                    MAX(1, :dirs)
+            ),
+            TopGlobalCommands AS (
+                SELECT
+                    cmd_tpl,
+                    COUNT(*) AS cmd_occurrence
+                FROM
+                    commands
+                WHERE
+                    length(cmd_tpl) >= :min_cmd_length
+                GROUP BY
+                    cmd_tpl
+                ORDER BY
+                    cmd_occurrence DESC
+                LIMIT
+                    :global_commands_to_ignore
+            ),
+            TopCommands AS (
+                SELECT
+                    dir,
+                    cmd_tpl,
+                    COUNT(*) AS cmd_occurrence,
+                    ROW_NUMBER() OVER (PARTITION BY dir ORDER BY COUNT(*) DESC) AS row_num
+                FROM
+                    commands
+                WHERE
+                    dir IN (SELECT dir FROM DirectoryCounts)
+                    AND cmd_tpl NOT IN (SELECT cmd_tpl FROM TopGlobalCommands)
+                    AND length(cmd_tpl) >= :min_cmd_length
+                GROUP BY
+                    dir, cmd_tpl
+            )
+            SELECT
+                dir,
+                cmd_tpl,
+                cmd_occurrence
+            FROM
+                TopCommands
+            WHERE
+                row_num <= :cmds
+            ORDER BY
+                dir, cmd_occurrence DESC
+        ";
+
+            self.history.run_query(
+                query,
+                &[
+                    (":dir_filter_off", &only_dir.is_none()),
+                    (":only_dir", &only_dir.as_ref().unwrap_or(&"".to_string())),
+                    (":min_cmd_length", &min_cmd_length.to_owned()),
+                    (":cmds", &cmds.to_owned()),
+                    (
+                        ":global_commands_to_ignore",
+                        &global_commands_to_ignore.to_owned(),
+                    ),
+                    (":dirs", &dirs.to_owned()),
+                ],
+                |row| {
+                    Ok(StatItem {
+                        dir: Some(row.get(0)?),
+                        cmd_tpl: row.get(1)?,
+                        count: row.get(2)?,
+                    })
+                },
+            )
+        } else {
+            let query = "
+                SELECT cmd_tpl, COUNT(1) AS n
+                FROM commands
+                WHERE length(cmd_tpl) >= :min_cmd_length
+                GROUP BY 1
+                ORDER BY 2 DESC
+                LIMIT :cmds
+            ";
+
+            self.history.run_query(
+                query,
+                &[
+                    (":min_cmd_length", &min_cmd_length.to_owned()),
+                    (":cmds", &cmds.to_owned()),
+                ],
+                |row| {
+                    Ok(StatItem {
+                        cmd_tpl: row.get(0)?,
+                        count: row.get(1)?,
+                        dir: None,
+                    })
+                },
+            )
+        }
     }
 
     #[inline]
     pub fn new(history: &'a History) -> Self {
         Self { history }
     }
-    fn count_commands_from_db_history(&self) -> i32 {
+    fn count_commands_from_db_history(&self, dir: &Option<String>) -> i32 {
         struct Count {
             count: i32,
         }
-        let vec = self
-            .history
-            .run_query("select count(1) as n from commands", &[], |row| {
-                Ok(Count { count: row.get(0)? })
-            });
+        let vec = self.history.run_query(
+            "SELECT count(1) AS n FROM commands WHERE (:dir_filter_off OR dir = :directory)",
+            &[
+                (":dir_filter_off", &dir.is_none()),
+                (":directory", &dir.as_ref().unwrap_or(&"".to_string())),
+            ],
+            |row| Ok(Count { count: row.get(0)? }),
+        );
         vec.first().unwrap().count
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use rusqlite::Connection;
-
-    use crate::history::History;
-    use crate::network::Network;
-    use crate::stats_generator::StatItem;
-
-    #[test]
-    fn empty_history() {
-        let history = History {
-            connection: Connection::open_in_memory().unwrap(),
-            network: Network::random(),
-        };
-        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
-        let lines = stats_generator.generate_command_stats(10, Vec::new());
-        assert_eq!(lines, "");
-    }
-
-    #[test]
-    fn partial_history() {
-        let history = History {
-            connection: Connection::open_in_memory().unwrap(),
-            network: Network::random(),
-        };
-        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
-        let lines = stats_generator.generate_command_stats(
-            3,
-            Vec::from([
-                StatItem {
-                    cmd: "git".to_string(),
-                    count: 10,
-                },
-                StatItem {
-                    cmd: "cargo".to_string(),
-                    count: 9,
-                },
-            ]),
-        );
-        assert_eq!(
-            lines,
-            "  - 2 first commands, sorted by occurrences:\n    git (10)\n    cargo (9)\n"
-        );
-    }
-
-    #[test]
-    fn full_history_with_simple_commands() {
-        let history = History {
-            connection: Connection::open_in_memory().unwrap(),
-            network: Network::random(),
-        };
-        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
-        let lines = stats_generator.generate_command_stats(
-            10,
-            Vec::from([
-                StatItem {
-                    cmd: "git".to_string(),
-                    count: 10,
-                },
-                StatItem {
-                    cmd: "cargo".to_string(),
-                    count: 9,
-                },
-            ]),
-        );
-        assert_eq!(
-            lines,
-            "  - 2 first commands, sorted by occurrences:\n    git (10)\n    cargo (9)\n"
-        );
-    }
-
-    #[test]
-    fn history_with_relative_and_full_path_commands() {
-        let history = History {
-            connection: Connection::open_in_memory().unwrap(),
-            network: Network::random(),
-        };
-        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
-        let lines = stats_generator.generate_command_stats(
-            10,
-            Vec::from([
-                StatItem {
-                    cmd: "./bin/docker".to_string(),
-                    count: 10,
-                },
-                StatItem {
-                    cmd: "/opt/local/share/docker".to_string(),
-                    count: 9,
-                },
-            ]),
-        );
-        assert_eq!(
-            lines,
-            "  - 2 first commands, sorted by occurrences:\n    docker (./bin) (10)\n    docker (/opt/local/share) (9)\n"
-        );
-    }
-
-    #[test]
-    fn command_stats_can_be_limited() {
-        let history = History {
-            connection: Connection::open_in_memory().unwrap(),
-            network: Network::random(),
-        };
-        let stats_generator = crate::stats_generator::StatsGenerator::new(&history);
-        let lines = stats_generator.generate_command_stats(
-            2,
-            Vec::from([
-                StatItem {
-                    cmd: "a".to_string(),
-                    count: 1,
-                },
-                StatItem {
-                    cmd: "be".to_string(),
-                    count: 2,
-                },
-            ]),
-        );
-        assert_eq!(
-            lines,
-            "  - 2 first commands, sorted by occurrences:\n    a (1)\n    be (2)\n"
-        );
     }
 }

--- a/src/stats_generator.rs
+++ b/src/stats_generator.rs
@@ -21,29 +21,29 @@ struct StatItem {
 impl<'a> StatsGenerator<'a> {
     pub fn generate_stats(&self, settings: &Settings) -> String {
         let mut lines = "".to_owned();
-        let count_history = Self::count_commands_from_db_history(self, &settings.stats_only_dir);
+        let count_history = Self::count_commands_from_db_history(self, &None);
         if count_history == 0 {
-            return if settings.stats_only_dir.is_some() {
-                format!(
-                    "No history found in {:?}",
-                    &settings.stats_only_dir.as_ref().unwrap()
-                )
-            } else {
-                "No history found in the database".to_string()
-            };
+            return "No history found in the database".to_string();
         }
         lines.push_str("📊 Quick stats:\n");
         if settings.stats_only_dir.is_some() {
             lines.push_str(
                 format!(
-                    "  - history has {:?} items in {:?}\n",
+                    "  - your history database contains {:?} items total and {:?} in {:?}\n",
                     count_history,
+                    Self::count_commands_from_db_history(self, &settings.stats_only_dir),
                     &settings.stats_only_dir.as_ref().unwrap()
                 )
                 .as_mut_str(),
             );
         } else {
-            lines.push_str(format!("  - history has {:?} items\n", count_history).as_mut_str());
+            lines.push_str(
+                format!(
+                    "  - your history database contains {:?} items\n",
+                    count_history
+                )
+                .as_mut_str(),
+            );
         }
         let most_used_commands = self.most_used_commands(
             settings.stats_cmds,
@@ -74,10 +74,14 @@ impl<'a> StatsGenerator<'a> {
 
         for (dir, items) in directory_map.iter() {
             if let Some(dir_name) = dir {
-                lines.push_str(&format!("  - Directory: {}\n", dir_name));
+                lines.push_str(&format!(
+                    "  - top {:?} matching commands in directory {:?}, sorted by occurrence:\n",
+                    min(cmds, items.len() as i16),
+                    dir_name
+                ));
             } else {
                 lines.push_str(&format!(
-                    "  - {:?} top filtered commands, sorted by occurrence:\n",
+                    "  - top {:?} matching commands, sorted by occurrence:\n",
                     min(cmds, items.len() as i16)
                 ));
             }


### PR DESCRIPTION
@nicokosi, I'd love your thoughts on this.

```
Usage: mcfly stats [OPTIONS]

Options:
  -m, --min-cmd-length <min_cmd_length>
          The minimum command length to be listed in the "top-n" commands [default: 0]
  -c, --cmds <cmds>
          The number of "top-n" commands [default: 10]
  -d, --dirs <dirs>
          Break down by top directories - defaults to 0, which doesn't limit by directory [default: 0]
  -g, --global-commands-to-ignore <global_cmds_to_ignore>
          [default: 10]
  -o, --only-dir <ONLY_DIR>
          Only show commands from a given directory
  -h, --help
          Print help
```

```
mcfly stats -d 3 -c 3 -g 20
📊 Quick stats:
  - history has 67226 items
  - Directory: /Users/andrew/projects/rails-app
    ./bin/dev-docker up (324)
    rake db:migrate (255)
  - Directory: /Users/andrew/projects/rust/mcfly
    cargo test (154)
    cargo clippy (109)
  - Directory: /Users/andrew
    j rails (272)
    j mcfly (145)
```