### PR TITLE
Auto-fix Clippy pedantic warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,11 +13,11 @@ pub struct Cli {
     #[arg(short, long)]
     pub debug: bool,
 
-    /// Session ID to record or search under (defaults to $MCFLY_SESSION_ID)
+    /// Session ID to record or search under (defaults to $`MCFLY_SESSION_ID`)
     #[arg(long = "session_id")]
     pub session_id: Option<String>,
 
-    /// Shell history file to read from when adding or searching (defaults to $MCFLY_HISTORY)
+    /// Shell history file to read from when adding or searching (defaults to $`MCFLY_HISTORY`)
     #[arg(long = "mcfly_history")]
     pub mcfly_history: Option<PathBuf>,
 
@@ -36,14 +36,14 @@ pub enum SubCommand {
     /// Add commands to the history
     #[command(alias = "a")]
     Add {
-        /// The command that was run (default last line of $MCFLY_HISTORY file)
+        /// The command that was run (default last line of $`MCFLY_HISTORY` file)
         command: Vec<String>,
 
         /// Exit code of command
         #[arg(value_name = "EXIT_CODE", short, long)]
         exit: Option<i32>,
 
-        /// Also append command to the given file (e.q., .bash_history)
+        /// Also append command to the given file (e.q., .`bash_history`)
         #[arg(value_name = "HISTFILE", short, long)]
         append_to_histfile: Option<String>,
 
@@ -198,6 +198,7 @@ pub enum DumpFormat {
 }
 
 impl Cli {
+    #[must_use]
     pub fn is_init(&self) -> bool {
         matches!(self.command, SubCommand::Init { .. })
     }
@@ -205,6 +206,7 @@ impl Cli {
 
 impl SortOrder {
     #[inline]
+    #[must_use]
     pub fn to_str(&self) -> &'static str {
         match self {
             Self::Asc => "ASC",

--- a/src/command_input.rs
+++ b/src/command_input.rs
@@ -21,7 +21,7 @@ pub enum Move {
 }
 
 #[derive(Debug)]
-/// CommandInput data structure
+/// `CommandInput` data structure
 pub struct CommandInput {
     /// The command itself
     pub command: String,
@@ -82,7 +82,7 @@ impl CommandInput {
 
     pub fn delete(&mut self, cmd: Move) {
         let mut new_command = String::with_capacity(self.command.len());
-        let command_copy = self.command.to_owned();
+        let command_copy = self.command.clone();
         let vec = command_copy.grapheme_indices(true);
 
         match cmd {
@@ -229,7 +229,7 @@ impl CommandInput {
 
         let mut word_index: usize = 0;
         let mut found_word: bool = false;
-        let command_copy = self.command.to_owned();
+        let command_copy = self.command.clone();
         let vec = command_copy
             .grapheme_indices(true)
             .enumerate()
@@ -264,7 +264,7 @@ impl CommandInput {
     /// Return the index of the grapheme cluster that represents the start of the next word after
     /// the cursor.
     fn next_word_boundary(&self) -> usize {
-        let command_copy = self.command.to_owned();
+        let command_copy = self.command.clone();
 
         let grapheme_indices = command_copy.grapheme_indices(true);
 
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn display_works() {
         let input = CommandInput::from("foo bar baz");
-        assert_eq!(format!("{}", input), "foo bar baz");
+        assert_eq!(format!("{input}"), "foo bar baz");
     }
 
     #[test]

--- a/src/fake_typer.rs
+++ b/src/fake_typer.rs
@@ -12,9 +12,10 @@ extern "C" {
 pub fn use_tiocsti(string: &str) {
     for byte in string.as_bytes() {
         let a: *const u8 = byte;
-        if unsafe { ioctl(0, libc::TIOCSTI.try_into().unwrap(), a) } < 0 {
-            panic!("Error encountered when calling ioctl");
-        }
+        assert!(
+            unsafe { ioctl(0, libc::TIOCSTI.try_into().unwrap(), a) } >= 0,
+            "Error encountered when calling ioctl"
+        );
     }
 }
 

--- a/src/fixed_length_grapheme_string.rs
+++ b/src/fixed_length_grapheme_string.rs
@@ -21,6 +21,7 @@ impl Write for FixedLengthGraphemeString {
 }
 
 impl FixedLengthGraphemeString {
+    #[must_use]
     pub fn empty(max_grapheme_length: u16) -> FixedLengthGraphemeString {
         FixedLengthGraphemeString {
             string: String::new(),

--- a/src/history/db_extensions.rs
+++ b/src/history/db_extensions.rs
@@ -37,5 +37,5 @@ pub fn add_db_functions(db: &Connection) {
             Ok(network.output(&features))
         },
     )
-    .unwrap_or_else(|err| panic!("McFly error: Successful create_scalar_function ({})", err));
+    .unwrap_or_else(|err| panic!("McFly error: Successful create_scalar_function ({err})"));
 }

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -92,6 +92,7 @@ const IGNORED_COMMANDS: [&str; 7] = [
 ];
 
 impl History {
+    #[must_use]
     pub fn load(history_format: HistoryFormat) -> History {
         let db_path = Settings::mcfly_db_path();
         let history = if db_path.exists() {
@@ -151,11 +152,11 @@ impl History {
                                     ":cmd_tpl": &simplified_command.result,
                                     ":session_id": &session_id.to_owned(),
                                     ":when_run": &when_run.to_owned(),
-                                    ":exit_code": &exit_code.to_owned(),
+                                    ":exit_code": &exit_code.clone(),
                                     ":selected": &selected,
                                     ":dir": &dir.to_owned(),
                                     ":old_dir": &old_dir.to_owned(),
-                                }).unwrap_or_else(|err| panic!("McFly error: Insert into commands to work ({})", err));
+                                }).unwrap_or_else(|err| panic!("McFly error: Insert into commands to work ({err})"));
     }
 
     fn determine_if_selected_from_ui(&self, command: &str, session_id: &str, dir: &str) -> bool {
@@ -173,10 +174,7 @@ impl History {
                 ],
             )
             .unwrap_or_else(|err| {
-                panic!(
-                    "McFly error: DELETE from selected_commands to work ({})",
-                    err
-                )
+                panic!("McFly error: DELETE from selected_commands to work ({err})")
             });
 
         // Delete any other pending selected commands for this session -- they must have been aborted or edited.
@@ -186,10 +184,7 @@ impl History {
                 &[(":session_id", &session_id.to_owned())],
             )
             .unwrap_or_else(|err| {
-                panic!(
-                    "McFly error: DELETE from selected_commands to work ({})",
-                    err
-                )
+                panic!("McFly error: DELETE from selected_commands to work ({err})")
             });
 
         rows_affected > 0
@@ -201,7 +196,7 @@ impl History {
                                           (":cmd", &command.to_owned()),
                                           (":session_id", &session_id.to_owned()),
                                           (":dir", &dir.to_owned())
-                                      ]).unwrap_or_else(|err| panic!("McFly error: Insert into selected_commands to work ({})", err));
+                                      ]).unwrap_or_else(|err| panic!("McFly error: Insert into selected_commands to work ({err})"));
     }
 
     // Update historical paths in our database if a directory has been renamed or moved.
@@ -290,14 +285,14 @@ impl History {
         let mut statement = self
             .connection
             .prepare(query)
-            .unwrap_or_else(|err| panic!("McFly error: Prepare to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Prepare to work ({err})"));
         let command_iter = statement
             .query_map(
                 named_params! { ":like": &like_query, ":limit": &num },
                 |row| {
                     let text: String = row
                         .get(1)
-                        .unwrap_or_else(|err| panic!("McFly error: cmd to be readable ({})", err));
+                        .unwrap_or_else(|err| panic!("McFly error: cmd to be readable ({err})"));
 
                     let lowercase_text = text.to_lowercase();
                     let lowercase_cmd = cmd.to_lowercase();
@@ -332,84 +327,81 @@ impl History {
 
                     Ok(Command {
                         id: row.get(0).unwrap_or_else(|err| {
-                            panic!("McFly error: id to be readable ({})", err)
+                            panic!("McFly error: id to be readable ({err})")
                         }),
                         cmd: text,
                         cmd_tpl: row.get(2).unwrap_or_else(|err| {
-                            panic!("McFly error: cmd_tpl to be readable ({})", err)
+                            panic!("McFly error: cmd_tpl to be readable ({err})")
                         }),
                         session_id: row.get(3).unwrap_or_else(|err| {
-                            panic!("McFly error: session_id to be readable ({})", err)
+                            panic!("McFly error: session_id to be readable ({err})")
                         }),
                         when_run: row.get(4).unwrap_or_else(|err| {
-                            panic!("McFly error: when_run to be readable ({})", err)
+                            panic!("McFly error: when_run to be readable ({err})")
                         }),
                         exit_code: row.get(5).unwrap_or_else(|err| {
-                            panic!("McFly error: exit_code to be readable ({})", err)
+                            panic!("McFly error: exit_code to be readable ({err})")
                         }),
                         selected: row.get(6).unwrap_or_else(|err| {
-                            panic!("McFly error: selected to be readable ({})", err)
+                            panic!("McFly error: selected to be readable ({err})")
                         }),
                         dir: row.get(7).unwrap_or_else(|err| {
-                            panic!("McFly error: dir to be readable ({})", err)
+                            panic!("McFly error: dir to be readable ({err})")
                         }),
                         rank: row.get(8).unwrap_or_else(|err| {
-                            panic!("McFly error: rank to be readable ({})", err)
+                            panic!("McFly error: rank to be readable ({err})")
                         }),
                         match_bounds: bounds,
                         features: Features {
                             age_factor: row.get(9).unwrap_or_else(|err| {
-                                panic!("McFly error: age_factor to be readable ({})", err)
+                                panic!("McFly error: age_factor to be readable ({err})")
                             }),
                             length_factor: row.get(10).unwrap_or_else(|err| {
-                                panic!("McFly error: length_factor to be readable ({})", err)
+                                panic!("McFly error: length_factor to be readable ({err})")
                             }),
                             exit_factor: row.get(11).unwrap_or_else(|err| {
-                                panic!("McFly error: exit_factor to be readable ({})", err)
+                                panic!("McFly error: exit_factor to be readable ({err})")
                             }),
                             recent_failure_factor: row.get(12).unwrap_or_else(|err| {
                                 panic!(
-                                    "McFly error: recent_failure_factor to be readable ({})",
-                                    err
+                                    "McFly error: recent_failure_factor to be readable ({err})"
                                 )
                             }),
                             selected_dir_factor: row.get(13).unwrap_or_else(|err| {
-                                panic!("McFly error: selected_dir_factor to be readable ({})", err)
+                                panic!("McFly error: selected_dir_factor to be readable ({err})")
                             }),
                             dir_factor: row.get(14).unwrap_or_else(|err| {
-                                panic!("McFly error: dir_factor to be readable ({})", err)
+                                panic!("McFly error: dir_factor to be readable ({err})")
                             }),
                             overlap_factor: row.get(15).unwrap_or_else(|err| {
-                                panic!("McFly error: overlap_factor to be readable ({})", err)
+                                panic!("McFly error: overlap_factor to be readable ({err})")
                             }),
                             immediate_overlap_factor: row.get(16).unwrap_or_else(|err| {
                                 panic!(
-                                    "McFly error: immediate_overlap_factor to be readable ({})",
-                                    err
+                                    "McFly error: immediate_overlap_factor to be readable ({err})"
                                 )
                             }),
                             selected_occurrences_factor: row.get(17).unwrap_or_else(|err| {
                                 panic!(
-                                    "McFly error: selected_occurrences_factor to be readable ({})",
-                                    err
+                                    "McFly error: selected_occurrences_factor to be readable ({err})"
                                 )
                             }),
                             occurrences_factor: row.get(18).unwrap_or_else(|err| {
-                                panic!("McFly error: occurrences_factor to be readable ({})", err)
+                                panic!("McFly error: occurrences_factor to be readable ({err})")
                             }),
                         },
                         last_run: row.get(19).unwrap_or_else(|err| {
-                            panic!("McFly error: last_run to be readable ({})", err)
+                            panic!("McFly error: last_run to be readable ({err})")
                         }),
                     })
                 },
             )
-            .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({err})"));
 
         let mut names = Vec::new();
         for result in command_iter {
             names.push(result.unwrap_or_else(|err| {
-                panic!("McFly error: Unable to load command from DB ({})", err)
+                panic!("McFly error: Unable to load command from DB ({err})")
             }));
         }
 
@@ -448,12 +440,12 @@ impl History {
                         1.0 - (b_start + b_len) as f64 / (a_start + b_start + a_len + b_len) as f64;
 
                     PartialOrd::partial_cmp(
-                        &(b.rank + b_mod * fuzzy as f64),
-                        &(a.rank + a_mod * fuzzy as f64),
+                        &(b.rank + b_mod * f64::from(fuzzy)),
+                        &(a.rank + a_mod * f64::from(fuzzy)),
                     )
                     .unwrap_or(Ordering::Equal)
                 })
-                .collect()
+                .collect();
         }
 
         names
@@ -476,7 +468,7 @@ impl History {
         if last_commands.len() < lookback as usize {
             last_commands = self.last_command_templates(&None, lookback as i16, 0);
             while last_commands.len() < lookback as usize {
-                last_commands.push(String::from(""));
+                last_commands.push(String::new());
             }
         }
 
@@ -489,7 +481,7 @@ impl History {
 
         self.connection
             .execute("DROP TABLE IF EXISTS temp.contextual_commands;", [])
-            .unwrap_or_else(|err| panic!("McFly error: Removal of temp table to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Removal of temp table to work ({err})"));
 
         let (mut when_run_min, when_run_max): (f64, f64) = self
             .connection
@@ -498,7 +490,7 @@ impl History {
                 [],
                 |row| Ok((row.get_unwrap(0), row.get_unwrap(1))),
             )
-            .unwrap_or_else(|err| panic!("McFly error: Query to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Query to work ({err})"));
 
         if (when_run_min - when_run_max).abs() < f64::EPSILON {
             when_run_min -= 60.0 * 60.0;
@@ -601,15 +593,15 @@ impl History {
                 ":max_length": &max_length,
                 ":max_selected_occurrences": &max_selected_occurrences,
                 ":lookback": &lookback,
-                ":lookback_f64": &(lookback as f64),
-                ":last_commands0": &last_commands[0].to_owned(),
-                ":last_commands1": &last_commands[1].to_owned(),
-                ":last_commands2": &last_commands[2].to_owned(),
+                ":lookback_f64": &f64::from(lookback),
+                ":last_commands0": &last_commands[0].clone(),
+                ":last_commands1": &last_commands[1].clone(),
+                ":last_commands2": &last_commands[2].clone(),
                 ":start_time": &start_time.unwrap_or(0).to_owned(),
-                ":end_time": &end_time.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err)).as_secs() as i64).to_owned(),
-                ":now": &now.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err)).as_secs() as i64).to_owned(),
+                ":end_time": &end_time.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!("McFly error: Time went backwards ({err})")).as_secs() as i64).to_owned(),
+                ":now": &now.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_else(|err| panic!("McFly error: Time went backwards ({err})")).as_secs() as i64).to_owned(),
                 ":min_id": &min_id,
-            }).unwrap_or_else(|err| panic!("McFly error: Creation of temp table to work ({})", err));
+            }).unwrap_or_else(|err| panic!("McFly error: Creation of temp table to work ({err})"));
 
         self.connection
             .execute(
@@ -620,15 +612,12 @@ impl History {
                                     selected_occurrences_factor, occurrences_factor);",
                 [],
             )
-            .unwrap_or_else(|err| panic!("McFly error: Ranking of temp table to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Ranking of temp table to work ({err})"));
 
         self.connection
             .execute("CREATE INDEX temp.MyIndex ON contextual_commands(id);", [])
             .unwrap_or_else(|err| {
-                panic!(
-                    "McFly error: Creation of index on temp table to work ({})",
-                    err
-                )
+                panic!("McFly error: Creation of index on temp table to work ({err})")
             });
 
         // println!("Seconds: {}", (beginning_of_execution.elapsed().as_secs() as f64) + (beginning_of_execution.elapsed().subsec_nanos() as f64 / 1000_000_000.0));
@@ -643,9 +632,9 @@ impl History {
     ) -> Vec<Command> {
         let order = if random { "RANDOM()" } else { "id" };
         let query = if session_id.is_none() {
-            format!("SELECT id, cmd, cmd_tpl, session_id, when_run, exit_code, selected, dir FROM commands ORDER BY {} DESC LIMIT :limit OFFSET :offset", order)
+            format!("SELECT id, cmd, cmd_tpl, session_id, when_run, exit_code, selected, dir FROM commands ORDER BY {order} DESC LIMIT :limit OFFSET :offset")
         } else {
-            format!("SELECT id, cmd, cmd_tpl, session_id, when_run, exit_code, selected, dir FROM commands WHERE session_id = :session_id ORDER BY {} DESC LIMIT :limit OFFSET :offset", order)
+            format!("SELECT id, cmd, cmd_tpl, session_id, when_run, exit_code, selected, dir FROM commands WHERE session_id = :session_id ORDER BY {order} DESC LIMIT :limit OFFSET :offset")
         };
 
         let closure: fn(&Row) -> rusqlite::Result<Command> = |row| {
@@ -685,7 +674,7 @@ impl History {
 
         let rows: MappedRows<_> = statement
             .query_map(params, f)
-            .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Query Map to work ({err})"));
 
         let mut vec: Vec<T> = Vec::new();
         for row in rows.flatten() {
@@ -707,7 +696,7 @@ impl History {
     ) -> Vec<String> {
         self.commands(session_id, num, offset, false)
             .iter()
-            .map(|command| command.cmd_tpl.to_owned())
+            .map(|command| command.cmd_tpl.clone())
             .collect()
     }
 
@@ -718,10 +707,7 @@ impl History {
                 &[(":command", &command)],
             )
             .unwrap_or_else(|err| {
-                panic!(
-                    "McFly error: DELETE from selected_commands to work ({})",
-                    err
-                )
+                panic!("McFly error: DELETE from selected_commands to work ({err})")
             });
 
         self.connection
@@ -729,7 +715,7 @@ impl History {
                 "DELETE FROM commands WHERE cmd = :command",
                 &[(":command", &command)],
             )
-            .unwrap_or_else(|err| panic!("McFly error: DELETE from commands to work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: DELETE from commands to work ({err})"));
     }
 
     pub fn update_paths(&self, old_path: &str, new_path: &str, print_output: bool) {
@@ -754,7 +740,7 @@ impl History {
                        ":new_dir": &normalized_new_path,
                        ":length": &(normalized_old_path.chars().count() as u32 + 1),
                 })
-                .unwrap_or_else(|err| panic!("McFly error: dir UPDATE to work ({})", err));
+                .unwrap_or_else(|err| panic!("McFly error: dir UPDATE to work ({err})"));
 
             old_dir_update_statement
                 .execute(named_params! {
@@ -763,12 +749,11 @@ impl History {
                     ":new_dir": &normalized_new_path,
                     ":length": &(normalized_old_path.chars().count() as u32 + 1),
                 })
-                .unwrap_or_else(|err| panic!("McFly error: old_dir UPDATE to work ({})", err));
+                .unwrap_or_else(|err| panic!("McFly error: old_dir UPDATE to work ({err})"));
 
             if print_output {
                 println!(
-                    "McFly: Command database paths renamed from {} to {} (affected {} commands)",
-                    normalized_old_path, normalized_new_path, affected
+                    "McFly: Command database paths renamed from {normalized_old_path} to {normalized_new_path} (affected {affected} commands)"
                 );
             }
         } else if print_output {
@@ -820,7 +805,7 @@ impl History {
         );
         io::stdout()
             .flush()
-            .unwrap_or_else(|err| panic!("McFly error: STDOUT flush should work ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: STDOUT flush should work ({err})"));
 
         // Load this first to make sure it works before we create the DB.
         let commands =
@@ -831,7 +816,7 @@ impl History {
         let mcfly_db_dir = mcfly_db_path.parent().unwrap();
 
         fs::create_dir_all(mcfly_db_dir)
-            .unwrap_or_else(|_| panic!("Unable to create {:?}", mcfly_db_dir));
+            .unwrap_or_else(|_| panic!("Unable to create {mcfly_db_dir:?}"));
 
         // Make ~/.mcfly/history.db
         let mut connection = Connection::open(&mcfly_db_path)
@@ -862,22 +847,22 @@ impl History {
                       dir TEXT NOT NULL \
                   ); \
                   CREATE INDEX selected_command_session_cmds ON selected_commands (session_id, cmd);"
-        ).unwrap_or_else(|err| panic!("McFly error: Unable to initialize history db ({})", err));
+        ).unwrap_or_else(|err| panic!("McFly error: Unable to initialize history db ({err})"));
 
         let transaction = connection
             .transaction()
-            .unwrap_or_else(|err| panic!("McFly error: Unable to begin transaction ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Unable to begin transaction ({err})"));
         {
             let mut statement = transaction
                 .prepare("INSERT INTO commands (cmd, cmd_tpl, session_id, when_run, exit_code, selected) VALUES (:cmd, :cmd_tpl, :session_id, :when_run, :exit_code, :selected)")
-                .unwrap_or_else(|err| panic!("McFly error: Unable to prepare insert ({})", err));
+                .unwrap_or_else(|err| panic!("McFly error: Unable to prepare insert ({err})"));
             for command in commands {
                 if !IGNORED_COMMANDS.contains(&command.command.as_str()) {
                     let simplified_command = SimplifiedCommand::new(&command.command, true);
                     if !command.command.is_empty() && !simplified_command.result.is_empty() {
                         if let Err(e) = statement.execute(named_params! {
                             ":cmd": &command.command,
-                            ":cmd_tpl": &simplified_command.result.to_owned(),
+                            ":cmd_tpl": &simplified_command.result.clone(),
                             ":session_id": &"IMPORTED",
                             ":when_run": &command.when,
                             ":exit_code": &0,
@@ -894,7 +879,7 @@ impl History {
         }
         transaction
             .commit()
-            .unwrap_or_else(|err| panic!("McFly error: Unable to commit transaction: ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Unable to commit transaction: ({err})"));
 
         schema::first_time_setup(&connection);
 
@@ -908,7 +893,7 @@ impl History {
 
     fn from_db_path(path: PathBuf) -> History {
         let connection = Connection::open(path)
-            .unwrap_or_else(|err| panic!("McFly error: Unable to open history database ({})", err));
+            .unwrap_or_else(|err| panic!("McFly error: Unable to open history database ({err})"));
         db_extensions::add_db_functions(&connection);
         History {
             connection,

--- a/src/history_cleaner.rs
+++ b/src/history_cleaner.rs
@@ -21,12 +21,11 @@ pub fn clean(settings: &Settings, history: &History, command: &str) {
                     .or_else(|_| env::var("MCFLY_HISTFILE"))
                     .unwrap_or_else(|err| {
                         panic!(
-                            "McFly error: Please ensure that HISTFILE/MCFLY_HISTFILE is set ({})",
-                            err
+                            "McFly error: Please ensure that HISTFILE/MCFLY_HISTFILE is set ({err})"
                         )
                     }),
             );
-            shell_history::delete_lines(&histfile, settings.history_format, command)
+            shell_history::delete_lines(&histfile, settings.history_format, command);
         }
         // Fish integration does not use a MCFLY_HISTORY file because we can get the last command
         // during a fish_postexec function.
@@ -40,10 +39,7 @@ fn clean_temporary_files(mcfly_history: &Path, history_format: HistoryFormat, co
     let path = mcfly_history;
     if let Some(directory) = path.parent() {
         let expanded_path = fs::canonicalize(directory).unwrap_or_else(|err| {
-            panic!(
-                "McFly error: The contents of $MCFLY_HISTORY appear invalid ({})",
-                err
-            )
+            panic!("McFly error: The contents of $MCFLY_HISTORY appear invalid ({err})")
         });
         let paths = fs::read_dir(expanded_path).unwrap();
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -23,19 +23,19 @@ impl Init {
     }
     pub fn init_bash() {
         let script = include_str!("../mcfly.bash");
-        print!("{}", script);
+        print!("{script}");
     }
     pub fn init_zsh() {
         let script = include_str!("../mcfly.zsh");
-        print!("{}", script);
+        print!("{script}");
     }
     pub fn init_fish() {
         let script = include_str!("../mcfly.fish");
-        print!("{}", script);
+        print!("{script}");
     }
     pub fn init_pwsh() {
         let script = include_str!("../mcfly.ps1")
             .replace("::MCFLY::", env::current_exe().unwrap().to_str().unwrap());
-        print!("{}", script);
+        print!("{script}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,12 +32,12 @@ fn handle_addition(settings: &Settings) {
                 settings.when_run.unwrap_or(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err))
+                        .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({err})"))
                         .as_secs() as i64,
                 ),
                 settings.history_format,
             );
-            shell_history::append_history_entry(&command, &histfile, settings.debug)
+            shell_history::append_history_entry(&command, &histfile, settings.debug);
         }
     }
 }
@@ -72,7 +72,7 @@ fn handle_search(settings: &Settings) {
             }
 
             fs::write(path, &out)
-                .unwrap_or_else(|err| panic!("McFly error: unable to write to {}: {}", path, err));
+                .unwrap_or_else(|err| panic!("McFly error: unable to write to {path}: {err}"));
         } else {
             fake_typer::use_tiocsti(&cmd);
 
@@ -108,7 +108,7 @@ fn handle_stats(settings: &Settings) {
         settings.stats_top_command_limit,
         settings.stats_command_limit,
     );
-    println!("{}", stats);
+    println!("{stats}");
 }
 
 fn main() {

--- a/src/network.rs
+++ b/src/network.rs
@@ -70,6 +70,7 @@ impl Default for Network {
 }
 
 impl Network {
+    #[must_use]
     pub fn random() -> Network {
         let mut rng = rand::thread_rng();
 
@@ -98,6 +99,7 @@ impl Network {
         self.final_output = self.final_sum.tanh();
     }
 
+    #[must_use]
     pub fn dot(&self, features: &Features) -> f64 {
         let mut network_output = self.final_bias;
         for (node, output_weight) in self.hidden_nodes.iter().zip(self.final_weights.iter()) {
@@ -107,10 +109,12 @@ impl Network {
         network_output
     }
 
+    #[must_use]
     pub fn output(&self, features: &Features) -> f64 {
         self.dot(features).tanh()
     }
 
+    #[must_use]
     pub fn average_error(&self, generator: &TrainingSampleGenerator, records: usize) -> f64 {
         let mut error = 0.0;
         let mut samples = 0.0;

--- a/src/node.rs
+++ b/src/node.rs
@@ -18,6 +18,7 @@ pub struct Node {
 }
 
 impl Node {
+    #[must_use]
     pub fn random() -> Node {
         let mut rng = rand::thread_rng();
 
@@ -36,6 +37,7 @@ impl Node {
         }
     }
 
+    #[must_use]
     pub fn dot(&self, features: &Features) -> f64 {
         self.offset
             + features.age_factor * self.age
@@ -50,6 +52,7 @@ impl Node {
             + features.occurrences_factor * self.occurrences
     }
 
+    #[must_use]
     pub fn output(&self, features: &Features) -> f64 {
         self.dot(features).tanh()
     }

--- a/src/path_update_helpers.rs
+++ b/src/path_update_helpers.rs
@@ -1,8 +1,9 @@
 use crate::settings::pwd;
-use path_absolutize::*;
+use path_absolutize::Absolutize;
 use std::path::Path;
 use unicode_segmentation::UnicodeSegmentation;
 
+#[must_use]
 pub fn normalize_path(incoming_path: &str) -> String {
     let expanded_path = shellexpand::tilde(incoming_path).to_string();
     return Path::new(&expanded_path)
@@ -13,6 +14,7 @@ pub fn normalize_path(incoming_path: &str) -> String {
         .to_string();
 }
 
+#[must_use]
 pub fn parse_mv_command(command: &str) -> Vec<String> {
     let mut in_double_quote = false;
     let mut in_single_quote = false;
@@ -81,7 +83,7 @@ pub fn parse_mv_command(command: &str) -> Vec<String> {
         .iter()
         .skip(1)
         .filter(|s| !s.starts_with('-'))
-        .map(|s| s.to_owned())
+        .map(std::borrow::ToOwned::to_owned)
         .collect()
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -64,7 +64,7 @@ pub enum HistoryFormat {
     Bash,
 
     /// zsh format - commands in plain text, with multiline commands on multiple lines.
-    /// McFly does not currently handle joining these lines; they're treated as separate commands.
+    /// `McFly` does not currently handle joining these lines; they're treated as separate commands.
     /// If --zsh-extended-history was given, `extended_history` will be true, and we'll strip the
     /// timestamp from the beginning of each command.
     Zsh { extended_history: bool },
@@ -266,8 +266,7 @@ impl Settings {
                 .unwrap_or_else(|err| {
                     if !settings.skip_environment_check {
                         panic!(
-                            "McFly error: Please ensure that MCFLY_SESSION_ID contains a random session ID ({})",
-                            err
+                            "McFly error: Please ensure that MCFLY_SESSION_ID contains a random session ID ({err})"
                         )
                     } else {
                         String::new()
@@ -280,10 +279,7 @@ impl Settings {
             {
                 env::var("MCFLY_HISTORY").unwrap_or_else(|err| {
                     if !settings.skip_environment_check {
-                        panic!(
-                            "McFly error: Please ensure that MCFLY_HISTORY is set ({})",
-                            err
-                        )
+                        panic!("McFly error: Please ensure that MCFLY_HISTORY is set ({err})")
                     } else {
                         String::new()
                     }
@@ -293,7 +289,7 @@ impl Settings {
         });
 
         {
-            use crate::cli::HistoryFormat::*;
+            use crate::cli::HistoryFormat::{Bash, Fish, Zsh, ZshExtended};
             settings.history_format = match cli.history_format {
                 Bash => HistoryFormat::Bash,
                 Zsh => HistoryFormat::Zsh {
@@ -322,7 +318,7 @@ impl Settings {
                         SystemTime::now()
                             .duration_since(UNIX_EPOCH)
                             .unwrap_or_else(|err| {
-                                panic!("McFly error: Time went backwards ({})", err)
+                                panic!("McFly error: Time went backwards ({err})")
                             })
                             .as_secs() as i64,
                     )
@@ -432,7 +428,7 @@ impl Settings {
             SubCommand::Init { shell } => {
                 settings.mode = Mode::Init;
 
-                use crate::cli::InitMode::*;
+                use crate::cli::InitMode::{Bash, Fish, Powershell, Zsh};
                 settings.init_mode = match shell {
                     Bash => InitMode::Bash,
                     Zsh => InitMode::Zsh,
@@ -649,6 +645,7 @@ impl Settings {
     }
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_CACHE_DIR
+    #[must_use]
     pub fn mcfly_training_cache_path() -> PathBuf {
         let cache_dir = Settings::mcfly_xdg_dir().cache_dir().to_path_buf();
 
@@ -656,6 +653,7 @@ impl Settings {
     }
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_DATA_DIR
+    #[must_use]
     pub fn mcfly_db_path() -> PathBuf {
         let data_dir = Settings::mcfly_xdg_dir().data_dir().to_path_buf();
         if data_dir.exists() {
@@ -667,6 +665,7 @@ impl Settings {
     }
 
     // Use ~/.mcfly only if it already exists, otherwise create 'mcfly' folder in XDG_DATA_DIR
+    #[must_use]
     pub fn mcfly_config_path() -> PathBuf {
         let data_dir = Settings::mcfly_xdg_dir().data_dir().to_path_buf();
 
@@ -692,13 +691,10 @@ impl Settings {
 }
 
 #[cfg(not(windows))]
+#[must_use]
 pub fn pwd() -> String {
-    env::var("PWD").unwrap_or_else(|err| {
-        panic!(
-            "McFly error: Unable to determine current directory ({})",
-            err
-        )
-    })
+    env::var("PWD")
+        .unwrap_or_else(|err| panic!("McFly error: Unable to determine current directory ({err})"))
 }
 
 #[cfg(windows)]
@@ -731,6 +727,7 @@ fn is_env_var_truthy(name: &str) -> bool {
 impl TimeRange {
     /// Determine the range is full (`..`)
     #[inline]
+    #[must_use]
     pub fn is_full(&self) -> bool {
         self.since.is_none() && self.before.is_none()
     }

--- a/src/shell_history.rs
+++ b/src/shell_history.rs
@@ -54,22 +54,19 @@ fn has_leading_timestamp(line: &str) -> bool {
     matched_chars == 11
 }
 
+#[must_use]
 pub fn history_file_path() -> PathBuf {
     let path = PathBuf::from(
         env::var("HISTFILE")
             .or_else(|_| env::var("MCFLY_HISTFILE"))
             .unwrap_or_else(|err| {
                 panic!(
-            "McFly error: Please ensure HISTFILE or MCFLY_HISTFILE is set for your shell ({})",
-            err
+            "McFly error: Please ensure HISTFILE or MCFLY_HISTFILE is set for your shell ({err})"
         )
             }),
     );
     fs::canonicalize(path).unwrap_or_else(|err| {
-        panic!(
-            "McFly error: The contents of $HISTFILE/$MCFLY_HISTFILE appears invalid ({})",
-            err
-        )
+        panic!("McFly error: The contents of $HISTFILE/$MCFLY_HISTFILE appears invalid ({err})")
     })
 }
 
@@ -113,6 +110,7 @@ impl fmt::Display for HistoryCommand {
     }
 }
 
+#[must_use]
 pub fn full_history(path: &Path, history_format: HistoryFormat) -> Vec<HistoryCommand> {
     match history_format {
         HistoryFormat::Bash => {
@@ -120,7 +118,7 @@ pub fn full_history(path: &Path, history_format: HistoryFormat) -> Vec<HistoryCo
             let zsh_timestamp_and_duration_regex = Regex::new(r"^: [0-9]+:[0-9]+;").unwrap();
             let when = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err))
+                .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({err})"))
                 .as_secs() as i64;
             history_contents
                 .split('\n')
@@ -134,7 +132,7 @@ pub fn full_history(path: &Path, history_format: HistoryFormat) -> Vec<HistoryCo
             let zsh_timestamp_and_duration_regex = Regex::new(r"^: [0-9]+:[0-9]+;").unwrap();
             let when = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({})", err))
+                .unwrap_or_else(|err| panic!("McFly error: Time went backwards ({err})"))
                 .as_secs() as i64;
             history_contents
                 .split('\n')
@@ -174,6 +172,7 @@ pub fn full_history(path: &Path, history_format: HistoryFormat) -> Vec<HistoryCo
     }
 }
 
+#[must_use]
 pub fn last_history_line(path: &Path, history_format: HistoryFormat) -> Option<String> {
     // Could switch to https://github.com/mikeycgto/rev_lines
     full_history(path, history_format)
@@ -216,7 +215,7 @@ pub fn delete_last_history_entry_if_search(
         .into_iter()
         .map(|cmd| cmd.to_string())
         // Newline at end of file.
-        .chain(Some(String::from("")))
+        .chain(Some(String::new()))
         .collect::<Vec<String>>();
 
     fs::write(path, lines.join("\n"))
@@ -233,7 +232,7 @@ pub fn delete_lines(path: &Path, history_format: HistoryFormat, command: &str) {
         .filter(|cmd| !command.eq(&zsh_timestamp_and_duration_regex.replace(&cmd.command, "")))
         .map(|cmd| cmd.to_string())
         // Newline at end of file.
-        .chain(Some(String::from("")))
+        .chain(Some(String::new()))
         .collect::<Vec<String>>();
 
     fs::write(path, lines.join("\n"))
@@ -246,8 +245,7 @@ pub fn append_history_entry(command: &HistoryCommand, path: &Path, debug: bool) 
         .open(path)
         .unwrap_or_else(|err| {
             panic!(
-                "McFly error: please make sure the specified --append-to-histfile file ({:?}) exists ({})",
-                path, err
+                "McFly error: please make sure the specified --append-to-histfile file ({path:?}) exists ({err})"
             )
         });
 
@@ -255,7 +253,7 @@ pub fn append_history_entry(command: &HistoryCommand, path: &Path, debug: bool) 
         println!("McFly: Appended to file '{:?}': {}", &path, command);
     }
 
-    if let Err(e) = writeln!(file, "{}", command) {
+    if let Err(e) = writeln!(file, "{command}") {
         eprintln!("Couldn't append to file '{}': {}", path.display(), e);
     }
 }

--- a/src/simplified_command.rs
+++ b/src/simplified_command.rs
@@ -10,7 +10,7 @@ pub struct SimplifiedCommand {
 }
 
 #[allow(clippy::collapsible_if)]
-/// The goal of SimplifiedCommand is to produce a reduced approximation of the given command for template matching. It may
+/// The goal of `SimplifiedCommand` is to produce a reduced approximation of the given command for template matching. It may
 /// not produce an exact simplification. (For example, it does not handle deeply nested escaping, and it drops escape characters.)
 /// Possible enhancements:
 /// - Sort and expand command line options.

--- a/src/stats_generator.rs
+++ b/src/stats_generator.rs
@@ -18,14 +18,15 @@ struct StatItem {
 }
 
 impl<'a> StatsGenerator<'a> {
+    #[must_use]
     pub fn generate_stats(&self, limit: i16, command_limit: Option<i16>) -> String {
-        let mut lines = "".to_owned();
+        let mut lines = String::new();
         let count_history = Self::count_commands_from_db_history(self);
         if count_history == 0 {
             return "No history, no stats!".to_string();
         }
         lines.push_str("📊 Quick stats:\n");
-        lines.push_str(format!("  - history has {:?} items ;\n", count_history).as_mut_str());
+        lines.push_str(format!("  - history has {count_history:?} items ;\n").as_mut_str());
         let most_used_commands = self.most_used_commands(&limit, command_limit.unwrap_or(1));
         lines.push_str(&Self::generate_command_stats(
             self,
@@ -36,7 +37,7 @@ impl<'a> StatsGenerator<'a> {
     }
 
     fn generate_command_stats(&self, limit: i16, stats: Vec<StatItem>) -> String {
-        let mut lines = "".to_owned();
+        let mut lines = String::new();
         if !stats.is_empty() {
             lines.push_str(
                 format!(

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Local, TimeZone};
 
+#[must_use]
 pub fn parse_timestamp(s: &str) -> i64 {
     chrono_systemd_time::parse_timestamp_tz(s, Local)
         .unwrap_or_else(|err| panic!("McFly error: Failed to parse timestamp ({err})"))
@@ -8,6 +9,7 @@ pub fn parse_timestamp(s: &str) -> i64 {
 }
 
 #[inline]
+#[must_use]
 pub fn to_datetime(timestamp: i64) -> String {
     let utc = DateTime::from_timestamp(timestamp, 0).unwrap();
     Local.from_utc_datetime(&utc.naive_utc()).to_rfc3339()

--- a/src/trainer.rs
+++ b/src/trainer.rs
@@ -32,7 +32,7 @@ impl<'a> Trainer<'a> {
             .history
             .network
             .average_error(&generator, batch_size * 10);
-        println!("Current network error rate is {}", best_overall_error);
+        println!("Current network error rate is {best_overall_error}");
 
         loop {
             let mut best_restart_network = Network::random();
@@ -272,13 +272,11 @@ impl<'a> Trainer<'a> {
                             best_overall_network = best_restart_network;
 
                             println!(
-                                "New best overall for {:#?} with error {} (new best)",
-                                best_overall_network, best_overall_error
+                                "New best overall for {best_overall_network:#?} with error {best_overall_error} (new best)"
                             );
                         } else {
                             println!(
-                                "Best overall remains {:#?} with error {} (old)",
-                                best_overall_network, best_overall_error
+                                "Best overall remains {best_overall_network:#?} with error {best_overall_error} (old)"
                             );
                         }
                         break;

--- a/src/training_cache.rs
+++ b/src/training_cache.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 pub fn write(data_set: &[(Features, bool)], cache_path: &Path) {
     let mut writer = Writer::from_path(cache_path)
-        .unwrap_or_else(|err| panic!("McFly error: Expected to be able to write a CSV ({})", err));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to be able to write a CSV ({err})"));
     output_header(&mut writer);
 
     for (features, correct) in data_set {
@@ -14,22 +14,16 @@ pub fn write(data_set: &[(Features, bool)], cache_path: &Path) {
     }
 }
 
+#[must_use]
 pub fn read(cache_path: &Path) -> Vec<(Features, bool)> {
     let mut data_set: Vec<(Features, bool)> = Vec::new();
 
-    let mut reader = Reader::from_path(cache_path).unwrap_or_else(|err| {
-        panic!(
-            "McFly error: Expected to be able to read from CSV ({})",
-            err
-        )
-    });
+    let mut reader = Reader::from_path(cache_path)
+        .unwrap_or_else(|err| panic!("McFly error: Expected to be able to read from CSV ({err})"));
 
     for result in reader.records() {
         let record = result.unwrap_or_else(|err| {
-            panic!(
-                "McFly error: Expected to be able to unwrap cached result ({})",
-                err
-            )
+            panic!("McFly error: Expected to be able to unwrap cached result ({err})")
         });
 
         let features = Features {
@@ -66,10 +60,10 @@ fn output_header(writer: &mut Writer<File>) {
             "occurrences_factor",
             "correct",
         ])
-        .unwrap_or_else(|err| panic!("McFly error: Expected to write to CSV ({})", err));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to write to CSV ({err})"));
     writer
         .flush()
-        .unwrap_or_else(|err| panic!("McFly error: Expected to flush CSV ({})", err));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to flush CSV ({err})"));
 }
 
 fn output_row(writer: &mut Writer<File>, features: &Features, correct: bool) {
@@ -91,8 +85,8 @@ fn output_row(writer: &mut Writer<File>, features: &Features, correct: bool) {
                 String::from("f")
             },
         ])
-        .unwrap_or_else(|err| panic!("McFly error: Expected to write to CSV ({})", err));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to write to CSV ({err})"));
     writer
         .flush()
-        .unwrap_or_else(|err| panic!("McFly error: Expected to flush CSV ({})", err));
+        .unwrap_or_else(|err| panic!("McFly error: Expected to flush CSV ({err})"));
 }

--- a/src/training_sample_generator.rs
+++ b/src/training_sample_generator.rs
@@ -19,7 +19,7 @@ impl TrainingSampleGenerator {
             let mcfly_cache_dir = cache_path.parent().unwrap();
 
             fs::create_dir_all(mcfly_cache_dir)
-                .unwrap_or_else(|_| panic!("Unable to create {:?}", mcfly_cache_dir));
+                .unwrap_or_else(|_| panic!("Unable to create {mcfly_cache_dir:?}"));
 
             training_cache::write(&ds, &cache_path);
             ds
@@ -48,13 +48,13 @@ impl TrainingSampleGenerator {
             }
 
             if i % 100 == 0 {
-                println!("Done with {}", i);
+                println!("Done with {i}");
             }
 
             // Setup the cache for the time this command was recorded.
             // Unwrap is safe here because we check command.dir.is_none() above.
             history.build_cache_table(
-                &command.dir.to_owned().unwrap(),
+                &command.dir.clone().unwrap(),
                 &ResultFilter::Global,
                 &Some(command.session_id.clone()),
                 None,


### PR DESCRIPTION
Via:

    cargo clippy --fix -- -Wclippy::pedantic

After:

    cargo clippy -- -Wclippy::pedantic 2>&1| grep "warning:" | wc -l
    285

Now:

    cargo clippy -- -Wclippy::pedantic 2>&1| grep "warning:" | wc -l
    112

PS: several fixes relates to my own code changes from #420. :innocent: 