### PR TITLE
Avoid using Bash bindings conflicting with UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ If you have a very large history database and you notice that McFly launches slo
 
 ### Bash TIOCSTI
 
-Starting with Linux kernel version 6.2, some systems have disabled TIOCSTI (which McFly previously used to write the selected command). McFly works around this issue by using two "dummy" keybindings, which default to `Meta+1` and `Meta+2`. If you are using either of these for another purpose, you can set the `MCFLY_BASH_SEARCH_KEYBINDING` and `MCFLY_BASH_ACCEPT_LINE_KEYBINDING`, respectively, to something you are not using. If you would prefer to use the legacy TIOCSTI behavior, you can enable it by setting the `sysctl` variable `dev.tty.legacy_tiocsti` to `1` on your system and set the `MCFLY_BASH_USE_TIOCSTI` bash variable to `1`.
+Starting with Linux kernel version 6.2, some systems have disabled TIOCSTI (which McFly previously used to write the selected command). McFly works around this issue by using two "dummy" keybindings, which default to `ctrl-x 1` and `ctrl-x 2`. If you are using either of these for another purpose, you can set the `MCFLY_BASH_SEARCH_KEYBINDING` and `MCFLY_BASH_ACCEPT_LINE_KEYBINDING`, respectively, to something you are not using. If you would prefer to use the legacy TIOCSTI behavior, you can enable it by setting the `sysctl` variable `dev.tty.legacy_tiocsti` to `1` on your system and set the `MCFLY_BASH_USE_TIOCSTI` bash variable to `1`.
 
 ## HISTTIMEFORMAT
 

--- a/mcfly.bash
+++ b/mcfly.bash
@@ -7,8 +7,8 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
 
   # Setup MCFLY_HISTFILE and make sure it exists.
   export MCFLY_HISTFILE="${HISTFILE:-$HOME/.bash_history}"
-  export MCFLY_BASH_SEARCH_KEYBINDING=${MCFLY_BASH_SEARCH_KEYBINDING:-"\M-1"}
-  export MCFLY_BASH_ACCEPT_LINE_KEYBINDING=${MCFLY_BASH_ACCEPT_LINE_KEYBINDING:-"\M-2"}
+  export MCFLY_BASH_SEARCH_KEYBINDING=${MCFLY_BASH_SEARCH_KEYBINDING:-"\C-x1"}
+  export MCFLY_BASH_ACCEPT_LINE_KEYBINDING=${MCFLY_BASH_ACCEPT_LINE_KEYBINDING:-"\C-x2"}
   if [[ ! -r "${MCFLY_HISTFILE}" ]]; then
     echo "McFly: ${MCFLY_HISTFILE} does not exist or is not readable. Please fix this or set HISTFILE to something else before using McFly."
     return 1


### PR DESCRIPTION
This fixes a regression introduced by PR #416. PR #416 uses `\M-1` and `\M-2` as intermediate sequences to call the shell function `mcfly_search` plus the readline bindable function `accept-line` (if necessary) by the keypress <kbd>C-r</kbd>. This makes it impossible to input Unicode characters whose UTF-8 representations contain a byte `\xB1` or `\xB2`. Note that at least 1/32 of multibyte Unicode characters contain `\xB1` or `\xB2` in its UTF-8 representation. Examples of such Unicode characters include `±`, `²`, and `ケ`.

### Details

`\M-1` and `\M-2` are interpreted by Readline as bytes `\xB1` and `\xB2`, respectively (under the default readline setting `set convert-meta off`). However, these bytes are used for *a part* of UTF-8 encoding (and do not form valid UTF-8 sequences by themselves), so one cannot input Unicode characters if those bytes are bound to something other than the bindable function `self-insert`. One should choose other sequences for the intermediate sequences.

The next option would be `\e1` and `\e2` (to which `\M-1` and `\M-2` would be converted when the user sets the readline setting `set convert-meta on`). They are interpreted as two-byte sequences, `\x1B\x31` and `\x1B\x32`, which are valid UTF-8 sequences each containing two code points. However, these are already bound to the bindable function `digit-argument` in the emacs keybinding of Realine by default. We want to avoid changing the meaning of existing bindings, which users may rely on.

In this PR, I suggest using `\C-x1` and `\C-x2` as the default intermediate sequences. In the `emacs` keymap of Readline, the byte `\C-x` is already used as a prefix key (i.e. the key to introduce multiple-key bindings), and the combinations `\C-x1` and `\C-x2` are not used by Readline by default. In the `vi-insert` keymap of Readline, the byte `\C-x` is not assigned to a special function but assigned to `self-insert` (just like other random *unused* control characters), so we may expect that `\C-x` can be safely overridden also in the `vi-insert` keymap.

### Context

The problem was first reported to Ref. [1] (where `ble.sh` basically rejects/escapes invalid UTF-8 bindings for safety, so a problem appears in a different way compared to the case in the plain Bash):

- [1] https://github.com/akinomyoga/ble.sh/issues/466

I'd like to kindly ask for a review or a suggestion, if any, from @jtschuster.


