### PR TITLE
Do not cancel the entire Bash/Zsh initialization on mcfly initialization failure

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Ensure stdin is a tty
-# Avoid loading this file more than once
-if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
+function mcfly_initialize {
+  unset -f "${FUNCNAME[0]}"
+
+  # Ensure stdin is a tty
+  [[ -t 0 ]] || return 0
+
+  # Avoid loading this file more than once
+  [[ "$__MCFLY_LOADED" != "loaded" ]] || return 0
   __MCFLY_LOADED="loaded"
 
   # Setup MCFLY_HISTFILE and make sure it exists.
@@ -120,5 +125,5 @@ if [[ -t 0 ]] && [[ "$__MCFLY_LOADED" != "loaded" ]]; then
       fi
     fi
   fi
-
-fi
+}
+mcfly_initialize

--- a/mcfly.zsh
+++ b/mcfly.zsh
@@ -1,7 +1,8 @@
 #!/bin/zsh
 
-# Ensure stdin is a tty
-if [[ -o interactive ]]; then
+() {
+  # Ensure stdin is a tty
+  [[ -o interactive ]] || return 0
 
   # Setup MCFLY_HISTFILE and make sure it exists.
   export MCFLY_HISTFILE="${HISTFILE:-$HOME/.zsh_history}"
@@ -100,5 +101,4 @@ if [[ -o interactive ]]; then
     zle -N mcfly-history-widget
     bindkey '^R' mcfly-history-widget
   fi
-
-fi
+}


### PR DESCRIPTION
The shell initialiation codes contain `return 1` at the top level. However, this causes the cancellation of the entire shell initialization because those codes are supposed to be evaluated as e.g. `eval "$(mcfly init bash)"`.  This is because the invocation of `return` in the eval'ed string takes an effect in the caller context of `eval`.

For example, with the following `~/.bashrc`,

```bash
# bashrc

eval "$(mcfly init bash)"

alias myalias='foo bar baz'
```

`myalias` would not be set up when the mcfly initialization fails because the mcfly initialization calls `return 1` at the top level, which cancels the execution of `~/.bashrc` (instead of just canceling the mcfly initialization).

This PR fixes the problem by enclosing the entire mcfly initialization in a shell function (or an anonymous function in Zsh) and allows returning from the enclosing function.
