### PR TITLE
Fix keyseq specification in Bash

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -119,9 +119,9 @@ function mcfly_initialize {
       #      which should be the commented-out search from step #1. It will then remove that line from the history file and
       #      render the search UI pre-filled with it.
       if set -o | grep "vi " | grep -q on; then
-        bind "'\C-r': '\e0i#mcfly: \e\C-m mcfly search\C-m'"
+        bind '"\C-r": "\e0i#mcfly: \e\C-m mcfly search\C-m"'
       else
-        bind "'\C-r': '\C-amcfly: \e# mcfly search\C-m'"
+        bind '"\C-r": "\C-amcfly: \e# mcfly search\C-m"'
       fi
     fi
   fi


### PR DESCRIPTION
The current way of setting the keyseq as `bind "'\C-r': '...'"` appears to work as expected, but this is accidental.  This is not the format that Readline supports; the keyseq cannot be enclosed within single quotes. This is now working because of Readline's loose treatment of the keyseqs, but this will easily be broken with a slightly different key representation.

Readline's interpretation of `'\C-r'` is as follows:

1. This doesn't start with the double quote, so Readline considers a legacy specification for a single key.
2. Readline splits the string with hyphens to extract the unmodified key name: `r'`.  This doesn't match any known key names such as `ESC`, `DEL`, etc., so Readline just picks up the first character `r`.
3. To obtain the set of modifiers, Readline searches for `C-` and `M-` against `'\C-r'`.  Now `C-` matches.
4. As a result, Readline generates the key "C-" plus "r", which *accidentally* matches the intended one.

However, this doesn't work e.g. with a different representation of C-r: `'\x12'`.  This time, the string doesn't contain a hyphen, so
Readline considers `'\x12'` is the full key name.  It doesn't match any known key name, so Readline extracts the first character `'` as the key, which is different from the intention.  One can confirm this interpretation by the following commands:

```bash
$ bind "'\x12': 'hello'"; bind -s
"'": "hello"        # <-- We here expect "\C-r" but it's instead interpreted as a single-quote character
$ bind '"\x12": "hello"'; bind -s
"\C-r": "hello"     # <-- "\C-r" works as expected.
"'": "hello"
```

In this PR, I suggest using the standard `"` instead of unsupported `'`. I modified it by reversing `'` and `"`. The macro string (i.e., the righ-hand side of `:`) can actually be quoted by single quotes, but I also modified it to `"` because it is easier for quoting.
