### PR TITLE
Bind to both emacs and vi-insert keymaps in Bash

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -141,11 +141,14 @@ function mcfly_initialize {
   if ((BASH_VERSINFO[0] >= 4)); then
     # shellcheck disable=SC2016
     if [[ ${MCFLY_BASH_USE_TIOCSTI-} == 1 ]]; then
-      bind -x '"\C-r": "mcfly_search_with_tiocsti"'
+      bind -m emacs     -x '"\C-r": "mcfly_search_with_tiocsti"'
+      bind -m vi-insert -x '"\C-r": "mcfly_search_with_tiocsti"'
     else
       # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).
-      bind -x "\"$MCFLY_BASH_SEARCH_KEYBINDING\":\"mcfly_search\""
-      bind "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEYBINDING$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\""
+      bind -m emacs     -x "\"$MCFLY_BASH_SEARCH_KEYBINDING\":\"mcfly_search\""
+      bind -m vi-insert -x "\"$MCFLY_BASH_SEARCH_KEYBINDING\":\"mcfly_search\""
+      bind -m emacs     "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEYBINDING$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\""
+      bind -m vi-insert "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEYBINDING$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\""
     fi
   else
     # The logic here is:
@@ -155,10 +158,8 @@ function mcfly_initialize {
     #   2. Type "mcfly search" and then run the command. McFly will pull the last line from the $MCFLY_HISTORY file,
     #      which should be the commented-out search from step #1. It will then remove that line from the history file and
     #      render the search UI pre-filled with it.
-    if [[ -o vi ]]; then
-      bind '"\C-r": "\e0i#mcfly: \e\C-m mcfly search\C-m"'
-    else
-      bind '"\C-r": "\C-amcfly: \e# mcfly search\C-m"'
+    bind -m emacs     '"\C-r": "\C-amcfly: \e# mcfly search\C-m"'
+    bind -m vi-insert '"\C-r": "\e0i#mcfly: \e\C-m mcfly search\C-m"'
     fi
   fi
 }


### PR DESCRIPTION
Thank you for reviewing all the PRs that I submitted so far!

This is the final PR. Unlike the previous ones, this is a suggestion for a change.

**Problem**: Bash has several keymaps depending on the current editing mode (i.e., the emacs editing mode or the vi editing mode). The default keymap for the vi editing mode is separate from the one for the emacs editing mode. Currently (in the `master` branch), the Bash keybindings are only set up *in the current keymap*. If the user changes the editing mode after `eval "$(mcfly init bash)"`, the keybindings become unavailable because the default keymap is switched.

For example, with the following bashrc, the keybindings are inactive:

```bash
# bashrc
eval "$(mcfly init bash)"
set -o vi
```

**Solution**: This PR registers the keybindings to both keymaps by explicitly specifying a keymap to register the keybindings.
