### PR TITLE
Only register key press in vim mode.

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -712,6 +712,9 @@ impl<'a> Interface<'a> {
     }
 
     fn select_with_vim_key_scheme(&mut self, event: KeyEvent) -> bool {
+        if event.kind != KeyEventKind::Press {
+            return false;
+        }
         if self.in_vim_insert_mode {
             match event {
                 KeyEvent {


### PR DESCRIPTION
This is in the emacs function but not vim. We previously register both key down and key up, causing two letters to be typed at a time.