### PR TITLE
Fix `chrono-systemd-time` broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,19 +225,16 @@ mcfly dump
 ```
 
 ### Timestamp format
-McFly use [chrono-systemd-time-ng] parsing timestamp.
 
-**chrono-systemd-time-ng** is a non-strict implementation of [systemd.time](https://www.freedesktop.org/software/systemd/man/systemd.time.html), with the following exceptions:
+McFly parses timestamps via `chrono-systemd-time`, a non-strict implementation of [systemd.time](https://www.freedesktop.org/software/systemd/man/systemd.time.html), with the following exceptions:
 * time units **must** accompany all time span values.
 * time zone suffixes are **not** supported.
 * weekday prefixes are **not** supported.
 
-Users of McFly simply need to understand **specifying timezone in timestamp isn't allowed**.
+McFly users simply need to understand **specifying timezone in timestamp isn't allowed**.
 McFly will always use your **local timezone**.
 
-For more details, please refer to [the document of chrono-systemd-time-ng][chrono-systemd-time-ng].
-
-[chrono-systemd-time-ng]: https://docs.rs/chrono-systemd-time-ng/latest/chrono_systemd_time/
+For more details, please refer to the [`chrono-systemd-time` documentation](https://docs.rs/chrono-systemd-time/latest/chrono_systemd_time/).
 
 ### Regex
 *Dump* supports filtering commands with regex.


### PR DESCRIPTION
Broken link has been detected via [Lychee](https://github.com/lycheeverse/lychee):

	❯ lychee --exclude-loopback --github-token $GITHUB_TOKEN README.md
	Issues found in 1 input. Find details below.

	[README.md]:
	✗ [404] https://docs.rs/chrono-systemd-time-ng/latest/chrono_systemd_time/ | Failed: Network error: Not Found

	🔍 11 Total (in 1s) ✅ 10 OK 🚫 1 Error

Also fixed typo and rephrased the "Timestamp format" paragraph.