### PR TITLE
Enable scrolling for results when exceeding window height

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -286,7 +286,7 @@ impl<'a> Interface<'a> {
                     screen,
                     cursor::MoveTo(
                         width - 9,
-                        (command_line_index + self.result_top_index() as i16) as u16
+                        (command_line_index + result_top_index as i16) as u16
                     )
                 )
                 .unwrap();
@@ -330,7 +330,7 @@ impl<'a> Interface<'a> {
                     screen,
                     cursor::MoveTo(
                         width - 9,
-                        (command_line_index + result_top_index as i16) as u16
+                        (command_line_index + self.result_top_index() as i16) as u16
                     ),
                     SetForegroundColor(timing_color),
                     Print(format!("{duration:>9}")),
@@ -343,17 +343,13 @@ impl<'a> Interface<'a> {
         }
 
         // Since we only clear by line instead of clearing the screen each update,
-        //  we need to clear all the lines that may have previously had a command.
+        //  we need to clear all the lines that may have previously had a command
         for i in index..result_height {
             let command_line_index = self.command_line_index(i as i16);
-            eprintln!(
-                "i={i}, command_line_index={}, result_top_index={}",
-                command_line_index, result_top_index
-            );
             queue!(
                 screen,
                 cursor::MoveTo(1, (command_line_index + result_top_index as i16) as u16),
-                Clear(ClearType::CurrentLine),
+                Clear(ClearType::CurrentLine)
             )
             .unwrap();
         }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -218,7 +218,8 @@ impl<'a> Interface<'a> {
         queue!(screen, cursor::Hide, cursor::MoveTo(1, result_top_index)).unwrap();
 
         let (width, height): (u16, u16) = terminal::size().unwrap();
-        let result_height = (height - RESULTS_TOP_INDEX) as usize;
+        let result_height = (height - RESULTS_TOP_INDEX) as usize
+            + if self.is_screen_view_bottom() { 1 } else { 0 };
 
         if !self.matches.is_empty() && self.selection > self.matches.len() - 1 {
             self.selection = self.matches.len() - 1;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -218,7 +218,7 @@ impl<'a> Interface<'a> {
         queue!(screen, cursor::Hide, cursor::MoveTo(1, result_top_index)).unwrap();
 
         let (width, height): (u16, u16) = terminal::size().unwrap();
-        let result_height = (height - result_top_index) as usize;
+        let result_height = (height - RESULTS_TOP_INDEX) as usize;
 
         if !self.matches.is_empty() && self.selection > self.matches.len() - 1 {
             self.selection = self.matches.len() - 1;
@@ -344,17 +344,18 @@ impl<'a> Interface<'a> {
 
         // Since we only clear by line instead of clearing the screen each update,
         //  we need to clear all the lines that may have previously had a command.
-        // If we don't enforce "index < result_height" the last line will be cleared.
-        if index < result_height {
-            for i in index..self.settings.results as usize {
-                let command_line_index = self.command_line_index(i as i16);
-                queue!(
-                    screen,
-                    cursor::MoveTo(1, (command_line_index + result_top_index as i16) as u16),
-                    Clear(ClearType::CurrentLine),
-                )
-                .unwrap();
-            }
+        for i in index..result_height {
+            let command_line_index = self.command_line_index(i as i16);
+            eprintln!(
+                "i={i}, command_line_index={}, result_top_index={}",
+                command_line_index, result_top_index
+            );
+            queue!(
+                screen,
+                cursor::MoveTo(1, (command_line_index + result_top_index as i16) as u16),
+                Clear(ClearType::CurrentLine),
+            )
+            .unwrap();
         }
     }
 


### PR DESCRIPTION
## Summary

This PR addresses issue #68.
The behavior has been modified to allow scrolling when the number of results exceeds the window height.

## Behavior

When `MCFLY_INTERFACE_VIEW=TOP`:

[Screencast from 2025年01月24日 00時44分33秒.webm](https://github.com/user-attachments/assets/c61862b8-8e58-46a0-a0bc-60d1a176de1f)

When `MCFLY_INTERFACE_VIEW=BOTTOM`:

[Screencast from 2025年01月24日 01時09分51秒.webm](https://github.com/user-attachments/assets/b0b75af4-fdd1-4be2-9d5a-f2cfee65443a)
