### PR TITLE
Highlight only the matched characters

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -412,16 +412,8 @@ impl History {
                     let a_start = *a.match_indices.first().unwrap_or(&0);
                     let b_start = *b.match_indices.first().unwrap_or(&0);
 
-                    let a_len = if fuzzy > 0 {
-                        a.match_indices.last().map(|i| i + 1).unwrap_or(0) - a_start
-                    } else {
-                        cmd.len()
-                    };
-                    let b_len = if fuzzy > 0 {
-                        b.match_indices.last().map(|i| i + 1).unwrap_or(0) - b_start
-                    } else {
-                        cmd.len()
-                    };
+                    let a_len = a.match_indices.last().map(|i| i + 1).unwrap_or(0) - a_start;
+                    let b_len = b.match_indices.last().map(|i| i + 1).unwrap_or(0) - b_start;
 
                     let a_mod =
                         1.0 - (a_start + a_len) as f64 / (a_start + b_start + a_len + b_len) as f64;

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -303,7 +303,7 @@ impl History {
                         .get(1)
                         .unwrap_or_else(|err| panic!("McFly error: cmd to be readable ({err})"));
 
-                    let bounds = Self::calc_match_bounds(&text, &cmd, fuzzy);
+                    let bounds = Self::calc_match_indices(&text, &cmd, fuzzy);
 
                     Ok(Command {
                         id: row.get(0).unwrap_or_else(|err| {
@@ -409,16 +409,16 @@ impl History {
                     // the likelihood of the weight flipping the outcome for
                     // the originally lower-ranked result.
 
-                    let a_start = *a.match_indices.first().unwrap();
-                    let b_start = *b.match_indices.first().unwrap();
+                    let a_start = *a.match_indices.first().unwrap_or(&0);
+                    let b_start = *b.match_indices.first().unwrap_or(&0);
 
                     let a_len = if fuzzy > 0 {
-                        a.match_indices.last().unwrap() + 1 - a_start
+                        a.match_indices.last().map(|i| i + 1).unwrap_or(0) - a_start
                     } else {
                         cmd.len()
                     };
                     let b_len = if fuzzy > 0 {
-                        b.match_indices.last().unwrap() + 1 - b_start
+                        b.match_indices.last().map(|i| i + 1).unwrap_or(0) - b_start
                     } else {
                         cmd.len()
                     };
@@ -445,7 +445,8 @@ impl History {
         cmd.chars().any(|c| c.is_uppercase())
     }
 
-    fn calc_match_bounds(text: &str, cmd: &str, fuzzy: i16) -> Vec<usize> {
+    /// Calculate the indices of the matches in the text.
+    fn calc_match_indices(text: &str, cmd: &str, fuzzy: i16) -> Vec<usize> {
         let (text, cmd) = if Self::is_case_sensitive(cmd) {
             (text.to_string(), cmd.to_string())
         } else {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -272,12 +272,7 @@ impl<'a> Interface<'a> {
                 SetBackgroundColor(bg),
                 SetForegroundColor(fg),
                 Print(Interface::truncate_for_display(
-                    command,
-                    &self.input.command,
-                    width,
-                    highlight,
-                    fg,
-                    self.debug
+                    command, width, highlight, fg, self.debug
                 ))
             )
             .unwrap();
@@ -991,7 +986,6 @@ impl<'a> Interface<'a> {
 
     fn truncate_for_display(
         command: &Command,
-        search: &str,
         width: u16,
         highlight_color: Color,
         base_color: Color,
@@ -1005,20 +999,18 @@ impl<'a> Interface<'a> {
         };
         let mut out = FixedLengthGraphemeString::empty(max_grapheme_length);
 
-        if !search.is_empty() {
-            let mut match_indices = command.match_indices.iter().peekable();
+        let mut match_indices = command.match_indices.iter().peekable();
 
-            for (i, c) in command.cmd.char_indices() {
-                match match_indices.peek() {
-                    Some(&&j) if i == j => {
-                        let _ = match_indices.next();
-                        execute!(out, SetForegroundColor(highlight_color)).unwrap();
-                        out.push_grapheme_str(c);
-                    }
-                    _ => {
-                        execute!(out, SetForegroundColor(base_color)).unwrap();
-                        out.push_grapheme_str(c);
-                    }
+        for (i, c) in command.cmd.char_indices() {
+            match match_indices.peek() {
+                Some(&&j) if i == j => {
+                    let _ = match_indices.next();
+                    execute!(out, SetForegroundColor(highlight_color)).unwrap();
+                    out.push_grapheme_str(c);
+                }
+                _ => {
+                    execute!(out, SetForegroundColor(base_color)).unwrap();
+                    out.push_grapheme_str(c);
                 }
             }
         }


### PR DESCRIPTION
- fix #455 
- fix #459 

Previously, all characters between the first and last matched characters were highlighted. This has been fixed to highlight only the characters that actually matched.

Additionally, due to the change in the behavior of the `find_matches` function, issue #459 has been resolved as a result.

---
![image](https://github.com/user-attachments/assets/048f022d-ddda-4e94-ad0a-6f8dd15dcf06)
