### PR TITLE
fix(bash): unbind Ctrl-R before rebinding on Bash 5.1 (fixes #470)

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -147,6 +147,13 @@ function mcfly_initialize {
       # Bind ctrl+r to 2 keystrokes, the first one is used to search in McFly, the second one is used to run the command (if mcfly_search binds it to accept-line).
       bind -m emacs     -x "\"$MCFLY_BASH_SEARCH_KEYBINDING\":\"mcfly_search\""
       bind -m vi-insert -x "\"$MCFLY_BASH_SEARCH_KEYBINDING\":\"mcfly_search\""
+      if ((BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] == 1)); then
+        # Workaround for Bash 5.1: overwriting an existing "bind -x" keybinding
+        # with a string macro breaks other existing "bind -x" keybindings.
+        # See https://github.com/cantino/mcfly/issues/470
+        bind -m emacs     -r '\C-r'
+        bind -m vi-insert -r '\C-r'
+      fi
       bind -m emacs     "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEYBINDING$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\""
       bind -m vi-insert "\"\C-r\":\"$MCFLY_BASH_SEARCH_KEYBINDING$MCFLY_BASH_ACCEPT_LINE_KEYBINDING\""
     fi


### PR DESCRIPTION
## Summary

- On Bash 5.1, explicitly unbind `\C-r` before binding it to the McFly search macro sequence.
- Prevents McFly from breaking unrelated user `bind -x` keybindings (e.g. `\C-g`) defined before sourcing `mcfly.bash`.

Fixes #470.

This matches the workaround used in [atuin#2975](https://github.com/atuinsh/atuin/pull/2975) for the same Bash 5.1 readline bug.

## Test plan

- [x] `cargo test`
- [ ] On Bash 5.1: bind `\C-g` with `-x`, source `mcfly.bash`, confirm `\C-g` binding remains (`bind -m emacs -X`)