### PR TITLE
fix(bash): respect string and array PROMPT_COMMAND on Bash 5.1+ (fixes #461)

### DIFF
--- a/mcfly.bash
+++ b/mcfly.bash
@@ -76,16 +76,16 @@ function mcfly_initialize {
 
   function mcfly_add_prompt_command {
     local command=$1 IFS=$' \t\n'
+    if [[ ";${PROMPT_COMMAND[*]-};" == *";${command};"* ]]; then
+      return 0
+    fi
     if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)); then
-      # Bash 5.1 supports array PROMPT_COMMAND, where we register our prompt
-      # command to a new element PROMPT_COMMAND[i] (with i >= 1) to avoid
-      # conflicts with other frameworks.
-      if [[ " ${PROMPT_COMMAND[*]-} " != *" $command "* ]]; then
-        PROMPT_COMMAND[0]=${PROMPT_COMMAND[0]:-}
-        # Note: We here use eval to avoid syntax error in Bash < 3.1.  We drop
-        # the support for Bash < 3.0, but this is still needed to avoid parse
-        # error before the Bash version check is performed.
-        eval 'PROMPT_COMMAND+=("$command")'
+      if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == declare\ -a* ]]; then
+        PROMPT_COMMAND+=("$command")
+      elif [[ -z ${PROMPT_COMMAND-} ]]; then
+        PROMPT_COMMAND="$command"
+      else
+        PROMPT_COMMAND="$command;${PROMPT_COMMAND#;}"
       fi
     elif [[ -z ${PROMPT_COMMAND-} ]]; then
       PROMPT_COMMAND="$command"


### PR DESCRIPTION
## Summary

- Detect whether `PROMPT_COMMAND` is a Bash array or a semicolon-separated string before registering `mcfly_prompt_command`.
- On Bash 5.1+, append to array hooks or prepend to string hooks without overwriting existing precmd chains.
- Use a unified duplicate check compatible with both representations.

Fixes #461.

Follows the same pattern as [direnv's bash hook](https://github.com/direnv/direnv/blob/master/gnu.bash): `declare -p PROMPT_COMMAND` distinguishes array vs string.

## Test plan

- [x] `cargo test`
- [ ] On Bash 5.1 with `PROMPT_COMMAND` as an array (e.g. bash-preexec): source `mcfly.bash`, confirm existing hooks remain
- [ ] On Bash 5.1 with string `PROMPT_COMMAND`: confirm McFly prepends without clobbering