### PR TITLE
Add MCFLY_HISTORY_IGNORE to skip recording matching commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ directories-next = "2.0"
 itertools = "0.14"
 rand = "0.9"
 path-absolutize = "3.1"
-regex = { version = "1", default-features = false, features = ["perf", "std"] }
+regex = { version = "1", default-features = false, features = ["perf", "std", "unicode-perl", "unicode-case"] }
 shellexpand = "3"
 unicode-segmentation = "1.11"
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,24 @@ $env:MCFLY_PROMPT=">"
 
 Note that only single-character-prompts are allowed. setting `MCFLY_PROMPT` to `"<str>"` will reset it to the default prompt.
 
+### Ignoring commands
+McFly already skips a few noisy commands (like `ls`, `cd`, and `pwd`) as well as anything you run with a leading space. To skip more, set `MCFLY_HISTORY_IGNORE` to a regular expression. Commands matching it will not be recorded. The pattern is unanchored, so add `^` if you want to match from the start of the command.
+
+bash / zsh:
+```bash
+export MCFLY_HISTORY_IGNORE="^(kubectl|helm) |password"
+```
+
+fish:
+```bash
+set -gx MCFLY_HISTORY_IGNORE "^(kubectl|helm) |password"
+```
+
+powershell:
+```powershell
+$env:MCFLY_HISTORY_IGNORE="^(kubectl|helm) |password"
+```
+
 ### Database Location
 
 McFly stores its SQLite database in the standard location for the OS. On OS X, this is in `~/Library/Application Support/McFly`, on Linux it is in `$XDG_DATA_DIR/mcfly/history.db` (default would be `~/.local/share/mcfly/history.db`), and on Windows, it is `%LOCALAPPDATA%\McFly\data\history.db`. For legacy support, if `~/.mcfly/` exists, it is used instead.

--- a/README.md
+++ b/README.md
@@ -456,21 +456,21 @@ $env:MCFLY_PROMPT=">"
 Note that only single-character-prompts are allowed. setting `MCFLY_PROMPT` to `"<str>"` will reset it to the default prompt.
 
 ### Ignoring commands
-McFly already skips a few noisy commands (like `ls`, `cd`, and `pwd`) as well as anything you run with a leading space. To skip more, set `MCFLY_HISTORY_IGNORE` to a regular expression. Commands matching it will not be recorded. The pattern is unanchored, so add `^` if you want to match from the start of the command.
+McFly already skips a few noisy commands (like `ls`, `cd`, and `pwd`) as well as anything you run with a leading space. To skip more, set `MCFLY_IGNORE_PATTERN` to a regular expression. Commands matching it will not be recorded. The pattern is unanchored, so add `^` if you want to match from the start of the command.
 
 bash / zsh:
 ```bash
-export MCFLY_HISTORY_IGNORE="^(kubectl|helm) |password"
+export MCFLY_IGNORE_PATTERN="^(kubectl|helm) |password"
 ```
 
 fish:
 ```bash
-set -gx MCFLY_HISTORY_IGNORE "^(kubectl|helm) |password"
+set -gx MCFLY_IGNORE_PATTERN "^(kubectl|helm) |password"
 ```
 
 powershell:
 ```powershell
-$env:MCFLY_HISTORY_IGNORE="^(kubectl|helm) |password"
+$env:MCFLY_IGNORE_PATTERN="^(kubectl|helm) |password"
 ```
 
 ### Database Location

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -93,7 +93,7 @@ const IGNORED_COMMANDS: [&str; 7] = [
 ];
 
 /// Returns true if `command` should never be recorded, either because of a built-in rule or because
-/// it matches the user's `MCFLY_HISTORY_IGNORE` pattern.
+/// it matches the user's `MCFLY_IGNORE_PATTERN` pattern.
 fn is_ignored_command(command: &str, commands_to_ignore: Option<&Regex>) -> bool {
     // Ignore empty commands.
     if command.is_empty() {
@@ -974,5 +974,16 @@ mod tests {
             Some(&pattern)
         ));
         assert!(!is_ignored_command("echo hello", Some(&pattern)));
+    }
+
+    #[test]
+    fn the_user_pattern_supports_unicode_perl_classes_and_case_folding() {
+        let pattern = Regex::new(r"(?i)password|\btoken\b").unwrap();
+        assert!(is_ignored_command(
+            "export API_PASSWORD=secret",
+            Some(&pattern)
+        ));
+        assert!(is_ignored_command("curl -H 'token: abc'", Some(&pattern)));
+        assert!(!is_ignored_command("git status", Some(&pattern)));
     }
 }

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -8,6 +8,7 @@ use crate::shell_history;
 use crate::simplified_command::SimplifiedCommand;
 use crate::time::to_datetime;
 use itertools::Itertools;
+use regex::Regex;
 use rusqlite::named_params;
 use rusqlite::types::ToSql;
 use rusqlite::{Connection, MappedRows, Row};
@@ -91,6 +92,39 @@ const IGNORED_COMMANDS: [&str; 7] = [
     "mcfly search",
 ];
 
+/// Returns true if `command` should never be recorded, either because of a built-in rule or because
+/// it matches the user's `MCFLY_HISTORY_IGNORE` pattern.
+fn is_ignored_command(command: &str, commands_to_ignore: Option<&Regex>) -> bool {
+    // Ignore empty commands.
+    if command.is_empty() {
+        return true;
+    }
+
+    // Ignore commands added via a ctrl-r search.
+    if command.starts_with("#mcfly:") {
+        return true;
+    }
+
+    // Ignore commands with a leading space.
+    if command.starts_with(' ') {
+        return true;
+    }
+
+    // Ignore built-in blacklisted commands.
+    if IGNORED_COMMANDS.contains(&command) {
+        return true;
+    }
+
+    // Ignore commands matching the user-supplied pattern.
+    if let Some(pattern) = commands_to_ignore
+        && pattern.is_match(command)
+    {
+        return true;
+    }
+
+    false
+}
+
 impl History {
     #[must_use]
     pub fn load(history_format: HistoryFormat) -> History {
@@ -104,24 +138,8 @@ impl History {
         history
     }
 
-    pub fn should_add(&self, command: &str) -> bool {
-        // Ignore empty commands.
-        if command.is_empty() {
-            return false;
-        }
-
-        // Ignore commands added via a ctrl-r search.
-        if command.starts_with("#mcfly:") {
-            return false;
-        }
-
-        // Ignore commands with a leading space.
-        if command.starts_with(' ') {
-            return false;
-        }
-
-        // Ignore blacklisted commands.
-        if IGNORED_COMMANDS.contains(&command) {
+    pub fn should_add(&self, command: &str, commands_to_ignore: Option<&Regex>) -> bool {
+        if is_ignored_command(command, commands_to_ignore) {
             return false;
         }
 
@@ -923,5 +941,38 @@ impl History {
             connection,
             network: Network::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ignored_command;
+    use regex::Regex;
+
+    #[test]
+    fn it_ignores_builtin_and_special_commands() {
+        assert!(is_ignored_command("", None));
+        assert!(is_ignored_command("#mcfly:git status", None));
+        assert!(is_ignored_command(" secret command", None));
+        assert!(is_ignored_command("ls", None));
+        assert!(!is_ignored_command("git status", None));
+    }
+
+    #[test]
+    fn it_ignores_commands_matching_the_user_pattern() {
+        let pattern = Regex::new("^(foo|bar) ").unwrap();
+        assert!(is_ignored_command("foo --baz", Some(&pattern)));
+        assert!(is_ignored_command("bar qux", Some(&pattern)));
+        assert!(!is_ignored_command("git commit", Some(&pattern)));
+    }
+
+    #[test]
+    fn the_user_pattern_leaves_unrelated_commands_alone() {
+        let pattern = Regex::new("password").unwrap();
+        assert!(is_ignored_command(
+            "mysql -u root -psuperpassword",
+            Some(&pattern)
+        ));
+        assert!(!is_ignored_command("echo hello", Some(&pattern)));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use mcfly::trainer::Trainer;
 
 fn handle_addition(settings: &Settings) {
     let history = History::load(settings.history_format);
-    if history.should_add(&settings.command) {
+    if history.should_add(&settings.command, settings.commands_to_ignore.as_ref()) {
         history.add(
             &settings.command,
             &settings.session_id,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -150,6 +150,7 @@ pub struct Settings {
     pub time_range: TimeRange,
     pub sort_order: SortOrder,
     pub pattern: Option<Regex>,
+    pub commands_to_ignore: Option<Regex>,
     pub dump_format: DumpFormat,
     pub colors: Colors,
     pub stats_min_cmd_length: i16,
@@ -192,6 +193,7 @@ impl Default for Settings {
             time_range: TimeRange::default(),
             sort_order: SortOrder::default(),
             pattern: None,
+            commands_to_ignore: None,
             dump_format: DumpFormat::default(),
             colors: Colors {
                 menubar_bg: Color::Blue,
@@ -265,6 +267,20 @@ impl Settings {
                 _ => ResultFilter::Global,
             },
             _ => ResultFilter::Global,
+        };
+
+        settings.commands_to_ignore = match env::var("MCFLY_HISTORY_IGNORE") {
+            Ok(val) if !val.is_empty() => match Regex::new(&val) {
+                Ok(re) => Some(re),
+                Err(err) => {
+                    // A bad pattern shouldn't stop commands from being recorded, so warn and carry on.
+                    eprintln!(
+                        "McFly error: MCFLY_HISTORY_IGNORE is not a valid regular expression ({err})"
+                    );
+                    None
+                }
+            },
+            _ => None,
         };
 
         settings.session_id = cli.session_id.unwrap_or_else(||

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -269,13 +269,13 @@ impl Settings {
             _ => ResultFilter::Global,
         };
 
-        settings.commands_to_ignore = match env::var("MCFLY_HISTORY_IGNORE") {
+        settings.commands_to_ignore = match env::var("MCFLY_IGNORE_PATTERN") {
             Ok(val) if !val.is_empty() => match Regex::new(&val) {
                 Ok(re) => Some(re),
                 Err(err) => {
                     // A bad pattern shouldn't stop commands from being recorded, so warn and carry on.
                     eprintln!(
-                        "McFly error: MCFLY_HISTORY_IGNORE is not a valid regular expression ({err})"
+                        "McFly error: MCFLY_IGNORE_PATTERN is not a valid regular expression ({err})"
                     );
                     None
                 }


### PR DESCRIPTION
Closes #86. Adds an `MCFLY_HISTORY_IGNORE` environment variable so you can keep specific commands out of your history. It's a regular expression, and any command matching it won't be recorded, running right alongside the existing built-in ignore list.

While I was in there I pulled the ignore checks out of `should_add` into a small `is_ignored_command` function so the new pattern sits next to the existing rules and can be unit tested without a database. Added a few tests for it and a README section.

On the shells mentioned in the issue, I went with a dedicated mcfly variable instead of reusing `HISTIGNORE` / `HISTORY_IGNORE`, since as @nmay231 pointed out those also affect the shell's own up-arrow history, which isn't necessarily what you want here. A bad pattern just warns and is ignored so it can't stop commands from being recorded.
