### PR TITLE
Remove unnecessary reference operators in panic messages

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -843,7 +843,7 @@ impl History {
 
         // Make ~/.mcfly/history.db
         let mut connection = Connection::open(&mcfly_db_path)
-            .unwrap_or_else(|_| panic!("Unable to create history DB at {:?}", &mcfly_db_path));
+            .unwrap_or_else(|_| panic!("Unable to create history DB at {:?}", mcfly_db_path));
 
         db_extensions::add_db_functions(&connection);
 
@@ -895,7 +895,7 @@ impl History {
                     {
                         println!(
                             "A single history line could not be saved due to '{}' (command was '{}'), but other inserts should be fine.",
-                            e, &command.command
+                            e, command.command
                         );
                     }
                 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -454,7 +454,7 @@ impl<'a> Interface<'a> {
 
         loop {
             let event =
-                read().unwrap_or_else(|e| panic!("McFly error: failed to read input {:?}", &e));
+                read().unwrap_or_else(|e| panic!("McFly error: failed to read input {:?}", e));
             self.debug_cursor(&mut screen);
 
             match self.menu_mode {

--- a/src/shell_history.rs
+++ b/src/shell_history.rs
@@ -14,20 +14,20 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 fn read_ignoring_utf_errors(path: &Path) -> String {
     let mut f =
-        File::open(path).unwrap_or_else(|_| panic!("McFly error: {:?} file not found", &path));
+        File::open(path).unwrap_or_else(|_| panic!("McFly error: {:?} file not found", path));
     let mut buffer = Vec::new();
     f.read_to_end(&mut buffer)
-        .unwrap_or_else(|_| panic!("McFly error: Unable to read from {:?}", &path));
+        .unwrap_or_else(|_| panic!("McFly error: Unable to read from {:?}", path));
     String::from_utf8_lossy(&buffer).to_string()
 }
 
 // Zsh uses a meta char (0x83) to signify that the previous character should be ^ 32.
 fn read_and_unmetafy(path: &Path) -> String {
     let mut f =
-        File::open(path).unwrap_or_else(|_| panic!("McFly error: {:?} file not found", &path));
+        File::open(path).unwrap_or_else(|_| panic!("McFly error: {:?} file not found", path));
     let mut buffer = Vec::new();
     f.read_to_end(&mut buffer)
-        .unwrap_or_else(|_| panic!("McFly error: Unable to read from {:?}", &path));
+        .unwrap_or_else(|_| panic!("McFly error: Unable to read from {:?}", path));
     for index in (0..buffer.len()).rev() {
         if buffer[index] == 0x83 {
             buffer.remove(index);
@@ -219,7 +219,7 @@ pub fn delete_last_history_entry_if_search(
         .collect::<Vec<String>>();
 
     fs::write(path, lines.join("\n"))
-        .unwrap_or_else(|_| panic!("McFly error: Unable to update {:?}", &path));
+        .unwrap_or_else(|_| panic!("McFly error: Unable to update {:?}", path));
 }
 
 pub fn delete_lines(path: &Path, history_format: HistoryFormat, command: &str) {
@@ -236,7 +236,7 @@ pub fn delete_lines(path: &Path, history_format: HistoryFormat, command: &str) {
         .collect::<Vec<String>>();
 
     fs::write(path, lines.join("\n"))
-        .unwrap_or_else(|_| panic!("McFly error: Unable to update {:?}", &path));
+        .unwrap_or_else(|_| panic!("McFly error: Unable to update {:?}", path));
 }
 
 pub fn append_history_entry(command: &HistoryCommand, path: &Path, debug: bool) {
@@ -250,7 +250,7 @@ pub fn append_history_entry(command: &HistoryCommand, path: &Path, debug: bool) 
         });
 
     if debug {
-        println!("McFly: Appended to file '{:?}': {}", &path, command);
+        println!("McFly: Appended to file '{:?}': {}", path, command);
     }
 
     if let Err(e) = writeln!(file, "{command}") {


### PR DESCRIPTION
This PR removes unnecessary reference operators (`&`) when passing variables to panic messages and println statements throughout the codebase.

## Summary
Cleaned up code style by eliminating redundant `&` operators in format string arguments. Since `panic!` and `println!` macros accept references implicitly through their format string parameters, the explicit `&` is unnecessary and reduces code clarity.

## Key Changes
- **src/shell_history.rs**: Removed `&` from `path` variable in 4 panic messages and 1 println statement
- **src/history/history.rs**: Removed `&` from `mcfly_db_path` in panic message and `command.command` in println statement
- **src/interface.rs**: Removed `&` from error variable `e` in panic message

## Details
The changes affect panic and print macro invocations where variables were being unnecessarily dereferenced before being passed to format strings. The macros handle the dereferencing automatically, making the explicit `&` redundant. This improves code readability without changing any functionality.

https://claude.ai/code/session_01Hgv8PfPUhyqZXjFT4g5SKV